### PR TITLE
Fix process detection bug

### DIFF
--- a/STROOP/Forms/StroopMainForm.cs
+++ b/STROOP/Forms/StroopMainForm.cs
@@ -510,7 +510,7 @@ namespace STROOP
             {
                 try
                 {
-                    if (!Config.Emulators.Select(e => e.ProcessName.ToLower()).Any(s => s.Contains(p.ProcessName.ToLower())))
+                    if (!Config.Emulators.Any(e => e.ProcessName.ToLower() == p.ProcessName.ToLower()))
                         continue;
 
                     if (p.HasExited)


### PR DESCRIPTION
When looking for emu processes, it was checking if any known emu name _contains_ the process name. But later, when determining which emu to use, it checks strict equality.

This means that if you try to connect to a process that is a substring of a known emu (e.g. mupen64.exe), STROOP crashes. The expected behavior is that it shouldn't list the emu at all.