### PR TITLE
Target .NET 4.6.1

### DIFF
--- a/STROOP/App.config
+++ b/STROOP/App.config
@@ -1,17 +1,17 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Scripting" publicKeyToken="7f709c5b713576e1" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+        <assemblyIdentity name="Microsoft.Scripting" publicKeyToken="7f709c5b713576e1" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Dynamic" publicKeyToken="7f709c5b713576e1" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+        <assemblyIdentity name="Microsoft.Dynamic" publicKeyToken="7f709c5b713576e1" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/STROOP/Properties/Resources.Designer.cs
+++ b/STROOP/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace STROOP.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/STROOP/Properties/Settings.Designer.cs
+++ b/STROOP/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace STROOP.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.1.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/STROOP/STROOP.csproj
+++ b/STROOP/STROOP.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>STROOP</RootNamespace>
     <AssemblyName>STROOP</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <IsWebBootstrapper>false</IsWebBootstrapper>
@@ -121,6 +121,9 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/STROOP/packages.config
+++ b/STROOP/packages.config
@@ -7,4 +7,5 @@
   <package id="OpenTK" version="1.1.1589.5942" targetFramework="net47" />
   <package id="OpenTK.GLControl" version="1.1.1589.5942" targetFramework="net47" />
   <package id="SharpZipLib" version="1.0.0" targetFramework="net47" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
The current target framework version is 4.7.1. However, this version brings compatibility issues with some modern Windows versions. In particular, as listed on [MSDN](https://docs.microsoft.com/en-us/dotnet/framework/get-started/system-requirements), this includes Windows 8, Windows 10 Release Build and Windows 10 November Update. Most affected are people who prefer staying on the old, release build of Windows 10 for various reasons (most importantly the ability to disable automatic updates), cannot run STROOP. I'm part of this minority myself.

Upon investigation, the app does not use any of the new features present only in 4.7 and above - except for System.ValueTuple. However, System.ValueTuple is available in older versions of .NET via a NuGet package, which allows normal operation on older versions without the need to change the source code. I've changed the target framework to version 4.6.1 and added System.ValueTuple as a Package. This should make it run properly on just about every modern system.