### PR TITLE
Fix Complaints About Not Supporting MupenLua

### DIFF
--- a/STROOP/Config/Config.xml
+++ b/STROOP/Config/Config.xml
@@ -4,6 +4,7 @@
     <Emulator name="Mupen 5.0 RR" processName="mupen64-rerecording" ramStart="0x008EBA80" endianness="little"/>
     <Emulator name="Mupen 5.0 RR" processName="mupen64-pucrash" ramStart="0x00912300" endianness="little"/>
     <Emulator name="Mupen 5.0 RR" processName="mupen64-lua" ramStart="0x00888F60" endianness="little"/>
+    <Emulator name="Mupen 5.0 RR" processName="mupen64_lua" ramStart="0x00888F60" endianness="little"/>
     <Emulator name="Mupen 5.0 RR" processName="mupen64-wiivc" ramStart="0x00901920" endianness="little"/>
     <Emulator name="Nemu64 0.8" processName="Nemu64" ramStart="0x10020000" endianness="little"/>
     <Emulator name="BizHawk" processName="EmuHawk" offsetDll="mupen64plus.dll" ramStart="0x6C370" endianness="little"/>


### PR DESCRIPTION
The default mupenlua download has a filename of mupen64_lua.exe. As this does not match the mupen64-lua executable name previously in STROOPs config file, STROOP will fail to pickup the default mupenlua download. This leads to lots of complaints about mupenlua not working in STROOP, as well as modified config files and older versions of STROOP being recommended. This addition of the default filename fixes these issues. The version with a hypen is left in for prior compatibility.