### PR TITLE
Lint the code and remove redundancy

### DIFF
--- a/STROOP/Calculators/CalculatorMain.cs
+++ b/STROOP/Calculators/CalculatorMain.cs
@@ -106,7 +106,7 @@ namespace STROOP.Structs
             ushort marioAngle = 24066;
 
             Dictionary<int, ushort> cameraAngles =
-                new Dictionary<int, ushort>()
+                new Dictionary<int, ushort>
                 {
                     //[0] = 32707,
                     [0] = 32768,
@@ -115,7 +115,7 @@ namespace STROOP.Structs
                     [3] = 32972,
                     [4] = 33063,
                     [5] = 33135,
-                    [6] = 33216,
+                    [6] = 33216
                 };
 
             float goalX = 374.529907226563f;
@@ -404,7 +404,7 @@ namespace STROOP.Structs
             ushort marioAngle = 16455;
 
             Dictionary<int, ushort> cameraAngles =
-                new Dictionary<int, ushort>()
+                new Dictionary<int, ushort>
                 {
                     [0] = 28563,
                     [1] = 28552,
@@ -412,7 +412,7 @@ namespace STROOP.Structs
                     [3] = 28533,
                     [4] = 28524,
                     [5] = 28514,
-                    [6] = 28500,
+                    [6] = 28500
                 };
 
             float goalX = 1060.860229f;
@@ -726,7 +726,7 @@ namespace STROOP.Structs
             float startZSpeed = -11.6073894500732f;
             float startHSpeed = 11.9047050476074f;
             ushort startAngle = 30442;
-            List<ushort> cameraAngles = new List<ushort>()
+            List<ushort> cameraAngles = new List<ushort>
             {
                 7997,
                 8089,
@@ -750,7 +750,7 @@ namespace STROOP.Structs
                 9249,
                 9249,
                 9249,
-                9249,
+                9249
             };
             int INDEX_START = 0;
 

--- a/STROOP/Calculators/HolpCalculator.cs
+++ b/STROOP/Calculators/HolpCalculator.cs
@@ -14,7 +14,7 @@ namespace STROOP.Structs
 {
     public static class HolpCalculator
     {
-        private static List<(int, double, double, double)> _data = new List<(int, double, double, double)>()
+        private static readonly List<(int, double, double, double)> _data = new List<(int, double, double, double)>
         {
             (0,-13.852560043335,82.7928466796875,43.2764892578125),
             (1,-13.8603839874268,84.1005249023438,43.2064208984375),
@@ -91,7 +91,7 @@ namespace STROOP.Structs
             (72,-13.9819869995117,77.0831298828125,44.716552734375),
             (73,-13.9631118774414,78.2352905273438,44.156494140625),
             (74,-13.8647117614746,79.316162109375,43.736083984375),
-            (75,-13.8919486999512,80.1707763671875,43.3465576171875),
+            (75,-13.8919486999512,80.1707763671875,43.3465576171875)
         };
 
         private static Dictionary<int, (double, double, double)> _dictionary;

--- a/STROOP/Calculators/WallDisplacementCalculator.cs
+++ b/STROOP/Calculators/WallDisplacementCalculator.cs
@@ -17,7 +17,7 @@ namespace STROOP.Structs
         public static (float newMarioX, float newMarioZ) HandleWallDisplacement(
             float marioX, float marioY, float marioZ, TriangleDataModel surf, float radius, float offsetY)
         {
-            return HandleWallDisplacement(marioX, marioY, marioZ, new List<TriangleDataModel>() { surf }, radius, offsetY);
+            return HandleWallDisplacement(marioX, marioY, marioZ, new List<TriangleDataModel> { surf }, radius, offsetY);
         }
 
         public static (float newMarioX, float newMarioZ) HandleWallDisplacement(

--- a/STROOP/Controls/FileHatLocationPictureBox.cs
+++ b/STROOP/Controls/FileHatLocationPictureBox.cs
@@ -22,16 +22,12 @@ namespace STROOP
         private Image _onImage;
         private Image _offImage;
 
-        public FileHatLocationPictureBox()
-        {
-        }
-
         public void Initialize(HatLocation definingHatLocation, Image onImage, Image offImage)
         {
             _definingHatLocation = definingHatLocation;
             _onImage = onImage;
             _offImage = offImage;
-            base.Initialize(0, 0);
+            Initialize(0, 0);
         }
 
         private HatLocation? GetCurrentHatLocation()

--- a/STROOP/Controls/ObjectSlot.cs
+++ b/STROOP/Controls/ObjectSlot.cs
@@ -375,7 +375,7 @@ namespace STROOP
 
         private List<bool> GetCurrentOverlayValues()
         {
-            return new List<bool>()
+            return new List<bool>
             {
                 _drawSelectedOverlay,
                 _drawStoodOnOverlay,
@@ -398,7 +398,7 @@ namespace STROOP
                 _drawCollision2Overlay,
                 _drawCollision3Overlay,
                 _drawCollision4Overlay,
-                _drawMarkedOverlay,
+                _drawMarkedOverlay
             };
         }
 

--- a/STROOP/Controls/VarHackContainer.cs
+++ b/STROOP/Controls/VarHackContainer.cs
@@ -353,7 +353,7 @@ namespace STROOP.Controls
             byte[] signedBytes = BitConverter.GetBytes(signed);
             WriteBytes(signedBytes, bytes, VarHackConfig.SignedOffset, true);
 
-            byte[] typeBytes = new byte[] { typeByte };
+            byte[] typeBytes = { typeByte };
             WriteBytes(typeBytes, bytes, VarHackConfig.TypeOffset, true);
 
             return bytes;

--- a/STROOP/Controls/VisualLinkLineText.cs
+++ b/STROOP/Controls/VisualLinkLineText.cs
@@ -82,7 +82,7 @@ namespace STROOP.Controls
 
             var a = new VisualLinkLineText(Text, ParentVisualLine, length, _clicked)
             {
-                RequireControlModifierForClick = RequireControlModifierForClick,
+                RequireControlModifierForClick = RequireControlModifierForClick
             };
             return a;
         }

--- a/STROOP/Controls/WatchVariableAngleWrapper.cs
+++ b/STROOP/Controls/WatchVariableAngleWrapper.cs
@@ -103,7 +103,7 @@ namespace STROOP.Controls
                     AngleUnitType.HAU,
                     AngleUnitType.Degrees,
                     AngleUnitType.Radians,
-                    AngleUnitType.Revolutions,
+                    AngleUnitType.Revolutions
                 },
                 (AngleUnitType angleUnitType) => { _angleUnitType = angleUnitType; },
                 _angleUnitType);

--- a/STROOP/Controls/WatchVariableControl.cs
+++ b/STROOP/Controls/WatchVariableControl.cs
@@ -378,7 +378,7 @@ namespace STROOP.Controls
             {
                 _watchVariablePanel.UnselectAllVariables();
                 SelectionForm.ShowDataManagerSelectionForm(
-                    new List<WatchVariableControl>() { this });
+                    new List<WatchVariableControl> { this });
             }
             else if (isNKeyHeld)
             {
@@ -540,7 +540,7 @@ namespace STROOP.Controls
             if (_settingsLevel < WatchVariableControlSettingsManager.GetSettingsLevel())
             {
                 WatchVariableControlSettingsManager.GetSettingsToApply(_settingsLevel)
-                    .ForEach(settings => ApplySettings(settings));
+                    .ForEach(ApplySettings);
                 _settingsLevel = WatchVariableControlSettingsManager.GetSettingsLevel();
             }
         }
@@ -743,7 +743,7 @@ namespace STROOP.Controls
             return WatchVarPrecursor.CreateWatchVariableControl(
                 VarName,
                 _baseColor,
-                new List<VariableGroup>() { VariableGroup.Custom },
+                new List<VariableGroup> { VariableGroup.Custom },
                 FixedAddressList);
         }
 
@@ -757,7 +757,7 @@ namespace STROOP.Controls
 
         public void AddToTab(DataManager dataManager, AddToTabTypeEnum? addToTabTypeNullable = null)
         {
-            AddVarsToTab(new List<WatchVariableControl>() { this }, dataManager, addToTabTypeNullable);
+            AddVarsToTab(new List<WatchVariableControl> { this }, dataManager, addToTabTypeNullable);
         }
 
         public static void AddVarsToTab(
@@ -773,8 +773,8 @@ namespace STROOP.Controls
                 List<List<uint>> addressesLists =
                     addToTabType == AddToTabTypeEnum.IndividualSpliced
                             || addToTabType == AddToTabTypeEnum.IndividualGrouped
-                        ? addressList.ConvertAll(address => new List<uint>() { address })
-                        : new List<List<uint>>() { addressList };
+                        ? addressList.ConvertAll(address => new List<uint> { address })
+                        : new List<List<uint>> { addressList };
                 for (int i = 0; i < addressesLists.Count; i++)
                 {
                     string name = watchVar.VarName;
@@ -788,7 +788,7 @@ namespace STROOP.Controls
                         watchVar.WatchVarPrecursor.CreateWatchVariableControl(
                             name,
                             watchVar._baseColor,
-                            new List<VariableGroup>() { VariableGroup.Custom },
+                            new List<VariableGroup> { VariableGroup.Custom },
                             constructorAddressList);
                     newVarList.Add(newControl);
                 }

--- a/STROOP/Controls/WatchVariableFlowLayoutPanel.cs
+++ b/STROOP/Controls/WatchVariableFlowLayoutPanel.cs
@@ -90,14 +90,14 @@ namespace STROOP.Controls
             ToolStripMenuItem openSaveClearItem = new ToolStripMenuItem("Open / Save / Clear ...");
             ControlUtilities.AddDropDownItems(
                 openSaveClearItem,
-                new List<string>() { "Open", "Open as Pop Out", "Save in Place", "Save As", "Clear" },
-                new List<Action>()
+                new List<string> { "Open", "Open as Pop Out", "Save in Place", "Save As", "Clear" },
+                new List<Action>
                 {
                     () => OpenVariables(),
                     () => OpenVariablesAsPopOut(),
                     () => SaveVariablesInPlace(),
                     () => SaveVariables(),
-                    () => ClearVariables(),
+                    () => ClearVariables()
                 });
 
             ToolStripMenuItem doToAllVariablesItem = new ToolStripMenuItem("Do to all variables...");
@@ -175,7 +175,7 @@ namespace STROOP.Controls
         {
             lock (_objectLock)
             {
-                AddVariables(new List<WatchVariableControl>() { watchVarControl });
+                AddVariables(new List<WatchVariableControl> { watchVarControl });
             }
         }
 
@@ -195,7 +195,7 @@ namespace STROOP.Controls
         public void RemoveVariable(WatchVariableControl watchVarControl)
         {
             // No need to lock, since this calls into a method that locks
-            RemoveVariables(new List<WatchVariableControl>() { watchVarControl });
+            RemoveVariables(new List<WatchVariableControl> { watchVarControl });
         }
 
         public void RemoveVariables(List<WatchVariableControl> watchVarControls)
@@ -224,7 +224,7 @@ namespace STROOP.Controls
 
         public void ShowOnlyVariableGroup(VariableGroup visibleVarGroup)
         {
-            ShowOnlyVariableGroups(new List<VariableGroup>() { visibleVarGroup });
+            ShowOnlyVariableGroups(new List<VariableGroup> { visibleVarGroup });
         }
 
         public void ShowOnlyVariableGroups(List<VariableGroup> visibleVarGroups)
@@ -339,11 +339,11 @@ namespace STROOP.Controls
         {
             if (_reorderingWatchVarControls.Count == 0)
             {
-                NotifyOfReorderingStart(new List<WatchVariableControl>() { watchVarControl });
+                NotifyOfReorderingStart(new List<WatchVariableControl> { watchVarControl });
             }
             else
             {
-                NotifyOfReorderingEnd(new List<WatchVariableControl>() { watchVarControl });
+                NotifyOfReorderingEnd(new List<WatchVariableControl> { watchVarControl });
             }
         }
 

--- a/STROOP/Controls/WatchVariableWrapper.cs
+++ b/STROOP/Controls/WatchVariableWrapper.cs
@@ -194,27 +194,27 @@ namespace STROOP.Controls
 
         public List<string> GetVarInfo()
         {
-            return new List<string>()
+            return new List<string>
             {
                 _watchVarControl.VarName,
                 GetClass(),
                 WatchVar.GetTypeDescription(),
                 WatchVar.GetBaseOffsetDescription(),
                 WatchVar.GetRamAddressListString(true, _watchVarControl.FixedAddressList),
-                WatchVar.GetProcessAddressListString(_watchVarControl.FixedAddressList),
+                WatchVar.GetProcessAddressListString(_watchVarControl.FixedAddressList)
             };
         }
 
         public static List<string> GetVarInfoLabels()
         {
-            return new List<string>()
+            return new List<string>
             {
                 "Name",
                 "Class",
                 "Type",
                 "Base + Offset",
                 "N64 Address",
-                "Emulator Address",
+                "Emulator Address"
             };
         }
 

--- a/STROOP/Forms/InfoForm.cs
+++ b/STROOP/Forms/InfoForm.cs
@@ -74,8 +74,7 @@ namespace STROOP.Forms
 
             textBoxTriangleInfo.Text = String.Join(
                 "\r\n",
-                uniqueVertexList.ConvertAll(
-                    coordinate => StringifyCoordinate(coordinate)));
+                uniqueVertexList.ConvertAll(StringifyCoordinate);
         }
 
         public void SetTriangles(List<TriangleDataModel> triangleList)

--- a/STROOP/Forms/InfoForm.cs
+++ b/STROOP/Forms/InfoForm.cs
@@ -74,7 +74,7 @@ namespace STROOP.Forms
 
             textBoxTriangleInfo.Text = String.Join(
                 "\r\n",
-                uniqueVertexList.ConvertAll(StringifyCoordinate);
+                uniqueVertexList.ConvertAll(StringifyCoordinate));
         }
 
         public void SetTriangles(List<TriangleDataModel> triangleList)

--- a/STROOP/Forms/MainLoadingForm.cs
+++ b/STROOP/Forms/MainLoadingForm.cs
@@ -23,8 +23,8 @@ namespace STROOP.Forms
             textBoxLoadingHelpfulHint.Text = HelpfulHintUtilities.GetRandomHelpfulHint();
             ControlUtilities.AddContextMenuStripFunctions(
                 textBoxLoadingHelpfulHint,
-                new List<string>() { "Show All Helpful Hints" },
-                new List<Action>() { () => HelpfulHintUtilities.ShowAllHelpfulHints() });
+                new List<string> { "Show All Helpful Hints" },
+                new List<Action> { HelpfulHintUtilities.ShowAllHelpfulHints });
         }
 
         private void LoadingForm_Load(object sender, EventArgs e)

--- a/STROOP/Forms/StroopMainForm.cs
+++ b/STROOP/Forms/StroopMainForm.cs
@@ -118,7 +118,7 @@ namespace STROOP
         {
             ControlUtilities.AddContextMenuStripFunctions(
                 labelVersionNumber,
-                new List<string>()
+                new List<string>
                 {
                     "Open Mapping",
                     "Inject Hitbox View Code",
@@ -133,9 +133,9 @@ namespace STROOP
                     "Show Image Form",
                     "Test Something",
                     "Test Something Else",
-                    "Format Subtitles",
+                    "Format Subtitles"
                 },
-                new List<Action>()
+                new List<Action>
                 {
                     () => MappingConfig.OpenMapping(),
                     () => Config.GfxManager.InjectHitboxViewCode(),
@@ -175,21 +175,21 @@ namespace STROOP
                     },
                     () => TestUtilities.TestSomething(),
                     () => TestUtilities.TestSomethingElse(),
-                    () => SubtitleUtilities.FormatSubtitlesFromClipboard(),
+                    () => SubtitleUtilities.FormatSubtitlesFromClipboard()
                 });
 
             ControlUtilities.AddCheckableContextMenuStripFunctions(
                 labelVersionNumber,
-                new List<string>()
+                new List<string>
                 {
                     "Disable Locking",
                     "Show Invisible Objects as Signs",
                     "Show Cog Tris",
                     "Show Shapes",
                     "Update Cam Hack Angle",
-                    "Update Floor Tri",
+                    "Update Floor Tri"
                 },
-                new List<Func<bool>>()
+                new List<Func<bool>>
                 {
                     () =>
                     {
@@ -220,28 +220,28 @@ namespace STROOP
                     {
                         TestingConfig.UpdateFloorTri = !TestingConfig.UpdateFloorTri;
                         return TestingConfig.UpdateFloorTri;
-                    },
+                    }
                 });
 
             ControlUtilities.AddContextMenuStripFunctions(
                 buttonMoveTabLeft,
-                new List<string>() { "Restore Recommended Tab Order" },
-                new List<Action>() { () => SavedSettingsConfig.InvokeRecommendedTabOrder() });
+                new List<string> { "Restore Recommended Tab Order" },
+                new List<Action> { () => SavedSettingsConfig.InvokeRecommendedTabOrder() });
 
             ControlUtilities.AddContextMenuStripFunctions(
                 buttonMoveTabRight,
-                new List<string>() { "Restore Recommended Tab Order" },
-                new List<Action>() { () => SavedSettingsConfig.InvokeRecommendedTabOrder() });
+                new List<string> { "Restore Recommended Tab Order" },
+                new List<Action> { () => SavedSettingsConfig.InvokeRecommendedTabOrder() });
 
             ControlUtilities.AddContextMenuStripFunctions(
                 buttonDisconnect,
-                new List<string>() { "Save as Savestate" },
-                new List<Action>() { () => saveAsSavestate() });
+                new List<string> { "Save as Savestate" },
+                new List<Action> { () => saveAsSavestate() });
         }
 
         private void CreateManagers()
         {
-            Config.MapGui = new MapGui()
+            Config.MapGui = new MapGui
             {
                 GLControlMap2D = glControlMap2D,
                 GLControlMap3D = glControlMap3D,
@@ -343,7 +343,7 @@ namespace STROOP
             };
 
             
-            M64Gui m64Gui = new M64Gui()
+            M64Gui m64Gui = new M64Gui
             {
                 LabelFileName = labelM64FileName,
                 LabelNumInputsValue = labelM64NumInputsValue,
@@ -401,7 +401,7 @@ namespace STROOP
                 TextBoxQuickDuplicationTotalIterations = textBoxM64QuickDuplicationTotalIterations,
                 ButtonQuickDuplicationDuplicate = buttonM64QuickDuplicationDuplicate,
 
-                ButtonAddPauseBufferFrames = buttonM64AddPauseBufferFrames,
+                ButtonAddPauseBufferFrames = buttonM64AddPauseBufferFrames
             };
 
             // Create managers

--- a/STROOP/Forms/VariableBitForm.cs
+++ b/STROOP/Forms/VariableBitForm.cs
@@ -57,8 +57,8 @@ namespace STROOP.Forms
 
             ControlUtilities.AddCheckableContextMenuStripItems(
                 this,
-                new List<string>() { "Show Value", "Show Float Components" },
-                new List<bool>() { false, true },
+                new List<string> { "Show Value", "Show Float Components" },
+                new List<bool> { false, true },
                 boolValue => _showFloatComponents = boolValue,
                 false);
         }

--- a/STROOP/Forms/VariableControllerForm.cs
+++ b/STROOP/Forms/VariableControllerForm.cs
@@ -27,9 +27,9 @@ namespace STROOP.Forms
 
         public VariableControllerForm(
             string varName, WatchVariableWrapper watchVarWrapper, List<uint> fixedAddressList) :
-                this (new List<string>() { varName },
-                      new List<WatchVariableWrapper>() { watchVarWrapper },
-                      new List<List<uint>>() { fixedAddressList })
+                this (new List<string> { varName },
+                      new List<WatchVariableWrapper> { watchVarWrapper },
+                      new List<List<uint>> { fixedAddressList })
         {
 
         }
@@ -66,8 +66,8 @@ namespace STROOP.Forms
             addTimer2.Tick += (s, e) => { addAction(true); };
             ControlUtilities.AddContextMenuStripFunctions(
                 _buttonAdd,
-                new List<string>() { "Start Continuous Add", "Stop Continuous Add" },
-                new List<Action>() { () => addTimer2.Start(), () => addTimer2.Stop() });
+                new List<string> { "Start Continuous Add", "Stop Continuous Add" },
+                new List<Action> { addTimer2.Start, addTimer2.Stop });
 
             Timer subtractTimer = new Timer { Interval = 30 };
             subtractTimer.Tick += (s, e) => { if (KeyboardUtilities.IsCtrlHeld()) addAction(false); };
@@ -78,8 +78,8 @@ namespace STROOP.Forms
             subtractTimer2.Tick += (s, e) => { addAction(false); };
             ControlUtilities.AddContextMenuStripFunctions(
                 _buttonSubtract,
-                new List<string>() { "Start Continuous Subtract", "Stop Continuous Subtract" },
-                new List<Action>() { () => subtractTimer2.Start(), () => subtractTimer2.Stop() });
+                new List<string> { "Start Continuous Subtract", "Stop Continuous Subtract" },
+                new List<Action> { subtractTimer2.Start, subtractTimer2.Stop });
 
             ToolStripMenuItem itemInvertedAdd = new ToolStripMenuItem("Inverted");
             ToolStripMenuItem itemInvertedSubtract = new ToolStripMenuItem("Inverted");

--- a/STROOP/Forms/VariableTripletControllerForm.cs
+++ b/STROOP/Forms/VariableTripletControllerForm.cs
@@ -40,11 +40,11 @@ namespace STROOP.Forms
                 {
                     if (controls.Count < 3) return;
 
-                    List<List<object>> valueLists = new List<List<object>>()
+                    List<List<object>> valueLists = new List<List<object>>
                     {
                         controls[0].GetValues(handleFormatting: false),
                         controls[1].GetValues(handleFormatting: false),
-                        controls[2].GetValues(handleFormatting: false),
+                        controls[2].GetValues(handleFormatting: false)
                     };
                     if (controls.Count >= 4)
                     {
@@ -56,19 +56,19 @@ namespace STROOP.Forms
                     for (int i = 0; i < minCount; i++)
                     {
                         int index = i;
-                        List<Func<double>> getters = new List<Func<double>>()
+                        List<Func<double>> getters = new List<Func<double>>
                         {
                             () => ParsingUtilities.ParseDouble(valueLists[0][index]),
                             () => ParsingUtilities.ParseDouble(valueLists[1][index]),
                             () => ParsingUtilities.ParseDouble(valueLists[2][index]),
-                            () => controls.Count >= 4 ? ParsingUtilities.ParseDouble(valueLists[3][index]) : double.NaN,
+                            () => controls.Count >= 4 ? ParsingUtilities.ParseDouble(valueLists[3][index]) : double.NaN
                         };
-                        List<Func<double, bool>> setters = new List<Func<double, bool>>()
+                        List<Func<double, bool>> setters = new List<Func<double, bool>>
                         {
                             (double value) => controls[0].SetValueOfValues(value, index),
                             (double value) => controls[1].SetValueOfValues(value, index),
                             (double value) => controls[2].SetValueOfValues(value, index),
-                            (double value) => controls.Count >= 4 ? controls[3].SetValueOfValues(value, index) : true,
+                            (double value) => controls.Count >= 4 ? controls[3].SetValueOfValues(value, index) : true
                         };
                         PositionAngle posAngle = PositionAngle.Functions(getters, setters);
                         posAngles.Add(posAngle);

--- a/STROOP/M64/M64CopiedData.cs
+++ b/STROOP/M64/M64CopiedData.cs
@@ -55,15 +55,15 @@ namespace STROOP.M64
 
         public static readonly M64CopiedData OneEmptyFrame =
             new M64CopiedData(0, 0, null, null, "One Empty Frame",
-                new List<M64CopiedFrame>() { M64CopiedFrame.OneEmptyFrame });
+                new List<M64CopiedFrame> { M64CopiedFrame.OneEmptyFrame });
 
         public static readonly M64CopiedData OnePauseFrame =
             new M64CopiedData(0, 0, null, null, "One Pause Frame",
-                new List<M64CopiedFrame>() { M64CopiedFrame.OnePauseFrame });
+                new List<M64CopiedFrame> { M64CopiedFrame.OnePauseFrame });
 
         public static readonly M64CopiedData OnePauseFrameOverwrite =
             new M64CopiedData(0, 0, null, null, "One Empty Frame",
-                new List<M64CopiedFrame>() { M64CopiedFrame.OnePauseFrameOverwrite });
+                new List<M64CopiedFrame> { M64CopiedFrame.OnePauseFrameOverwrite });
 
         public void Apply(List<M64InputFrame> inputs)
         {
@@ -76,13 +76,13 @@ namespace STROOP.M64
 
         public void Apply(M64InputFrame input)
         {
-            Apply(new List<M64InputFrame>() { input });
+            Apply(new List<M64InputFrame> { input });
         }
 
         public override string ToString()
         {
             if (_customName != null) return _customName;
-            return String.Format(
+            return string.Format(
                 "{0}f [{1}] {2}-{3} @{4}",
                 _totalFrames, _typeString, _startFrame, _endFrame, _fileName);
         }

--- a/STROOP/M64/M64Header.cs
+++ b/STROOP/M64/M64Header.cs
@@ -267,7 +267,7 @@ namespace STROOP.M64
 
         private List<bool> GetControllerBoolList()
         {
-            return new List<bool>()
+            return new List<bool>
             {
                 Controller1Present,
                 Controller2Present,
@@ -280,7 +280,7 @@ namespace STROOP.M64
                 Controller1RumblePak,
                 Controller2RumblePak,
                 Controller3RumblePak,
-                Controller4RumblePak,
+                Controller4RumblePak
             };
         }
 

--- a/STROOP/M64/M64InputFrame.cs
+++ b/STROOP/M64/M64InputFrame.cs
@@ -91,23 +91,23 @@ namespace STROOP.M64
 
         private List<object> GetOriginalValues()
         {
-            return new List<object>()
+            return new List<object>
             {
                 _X, _Y,
                 _A, _B, _Z, _S, _R,
                 _C_Up, _C_Down, _C_Left, _C_Right,
-                _L, _D_Up, _D_Down, _D_Left, _D_Right,
+                _L, _D_Up, _D_Down, _D_Left, _D_Right
             };
         }
 
         private List<object> GetCurrentValues()
         {
-            return new List<object>()
+            return new List<object>
             {
                 X, Y,
                 A, B, Z, S, R,
                 C_Up, C_Down, C_Left, C_Right,
-                L, D_Up, D_Down, D_Left, D_Right,
+                L, D_Up, D_Down, D_Left, D_Right
             };
         }
 

--- a/STROOP/M64/M64Utilities.cs
+++ b/STROOP/M64/M64Utilities.cs
@@ -17,7 +17,7 @@ namespace STROOP.M64
     public static class M64Utilities
     {
         public static readonly Dictionary<string, int> InputHeaderTextToIndex =
-            new Dictionary<string, int>()
+            new Dictionary<string, int>
             {
                 ["X"] = 0,
                 ["Y"] = 1,
@@ -43,7 +43,7 @@ namespace STROOP.M64
         public static readonly List<string> ButtonNameList = InputHeaderTexts.Skip(2).ToList();
 
         public static readonly List<Func<M64InputFrame, bool>> IsButtonPressedFunctionList =
-            new List<Func<M64InputFrame, bool>>()
+            new List<Func<M64InputFrame, bool>>
             {
                 input => input.A,
                 input => input.B,
@@ -144,7 +144,7 @@ namespace STROOP.M64
         }
 
         public static readonly List<(string, int, Color)> ColumnParameters =
-            new List<(string, int, Color)>()
+            new List<(string, int, Color)>
             {
                 ("Frame", M64Config.TextColumnFillWeight, M64Config.FrameColumnColor),
                 ("Id", M64Config.TextColumnFillWeight, M64Config.FrameColumnColor),

--- a/STROOP/Managers/ActionsManager.cs
+++ b/STROOP/Managers/ActionsManager.cs
@@ -29,27 +29,27 @@ namespace STROOP.Managers
 
             ControlUtilities.AddContextMenuStripFunctions(
                 textBoxActionDescription,
-                new List<string>() { "Select Action", "Free Movement Action", "Open Action Form" },
-                new List<Action>()
+                new List<string> { "Select Action", "Free Movement Action", "Open Action Form" },
+                new List<Action>
                 {
-                    () => SelectionForm.ShowActionDescriptionSelectionForm(),
+                    SelectionForm.ShowActionDescriptionSelectionForm,
                     () => Config.Stream.SetValue(MarioConfig.FreeMovementAction, MarioConfig.StructAddress + MarioConfig.ActionOffset),
-                    () => new ActionForm().Show(),
+                    () => new ActionForm().Show()
                 });
 
             ControlUtilities.AddContextMenuStripFunctions(
                 textBoxAnimationDescription,
-                new List<string>() { "Select Animation", "Replace Animation" },
-                new List<Action>()
+                new List<string> { "Select Animation", "Replace Animation" },
+                new List<Action>
                 {
-                    () => SelectionForm.ShowAnimationDescriptionSelectionForm(),
+                    SelectionForm.ShowAnimationDescriptionSelectionForm,
                     () =>
                     {
                         int? animationToBeReplaced = SelectionForm.GetAnimation("Choose Animation to Be Replaced", "Select Animation");
                         int? animationToReplaceIt = SelectionForm.GetAnimation("Choose Animation to Replace It", "Select Animation");
                         if (animationToBeReplaced == null || animationToReplaceIt == null) return;
                         AnimationUtilities.ReplaceAnimation(animationToBeReplaced.Value, animationToReplaceIt.Value);
-                    },
+                    }
                 });
         }
 

--- a/STROOP/Managers/CamHackManager.cs
+++ b/STROOP/Managers/CamHackManager.cs
@@ -33,10 +33,10 @@ namespace STROOP.Managers
             Label labelCamHackMode = splitContainer.Panel1.Controls["labelCamHackMode"] as Label;
             ControlUtilities.AddContextMenuStripFunctions(
                 labelCamHackMode,
-                new List<string>() { "Download Camera Hack ROM" },
-                new List<Action>()
+                new List<string> { "Download Camera Hack ROM" },
+                new List<Action>
                 {
-                    () => System.Diagnostics.Process.Start("http://download1436.mediafire.com/t3unklq170ag/hdd377v5794u319/Camera+Hack+ROM.z64"),
+                    () => System.Diagnostics.Process.Start("http://download1436.mediafire.com/t3unklq170ag/hdd377v5794u319/Camera+Hack+ROM.z64")
                 });
 
         _mode0RadioButton = splitContainer.Panel1.Controls["radioButtonCamHackMode0"] as RadioButton;
@@ -291,7 +291,7 @@ namespace STROOP.Managers
                 CreatePanVar(String.Format("Pan{0} Cam Radius End", index), String.Format("Pan{0}RadiusEnd", index), "Blue"),
 
                 CreatePanVar(String.Format("Pan{0} FOV Start", index), String.Format("Pan{0}FOVStart", index), "Pink"),
-                CreatePanVar(String.Format("Pan{0} FOV End", index), String.Format("Pan{0}FOVEnd", index), "Pink"),
+                CreatePanVar(String.Format("Pan{0} FOV End", index), String.Format("Pan{0}FOVEnd", index), "Pink")
             };
         }
 

--- a/STROOP/Managers/CoinManager.cs
+++ b/STROOP/Managers/CoinManager.cs
@@ -186,8 +186,7 @@ namespace STROOP.Managers
 
                 if (!_checkBoxCoinCustomizatonDisplayNonQualifiedCoinsOfAQualifiedCoinGroup.Checked)
                 {
-                    coinTrajectories = coinTrajectories.FindAll(
-                        coinTrajectory => filter.Qualifies(coinTrajectory));
+                    coinTrajectories = coinTrajectories.FindAll(filter.Qualifies);
                 }
 
                 List<double> hSpeedList = coinTrajectories.ConvertAll(

--- a/STROOP/Managers/CustomManager.cs
+++ b/STROOP/Managers/CustomManager.cs
@@ -48,11 +48,11 @@ namespace STROOP.Managers
             buttonClearVars.Click += (sender, e) => _variablePanel.ClearVariables();
             ControlUtilities.AddContextMenuStripFunctions(
                 buttonClearVars,
-                new List<string>() { "Clear All Vars", "Clear Default Vars" },
-                new List<Action>()
+                new List<string> { "Clear All Vars", "Clear Default Vars" },
+                new List<Action>
                 {
-                    () => _variablePanel.ClearVariables(),
-                    () => _variablePanel.RemoveVariableGroup(VariableGroup.NoGroup),
+                    _variablePanel.ClearVariables,
+                    () => _variablePanel.RemoveVariableGroup(VariableGroup.NoGroup)
                 });
 
             _checkBoxCustomRecordValues = splitContainerCustomControls.Panel1.Controls["checkBoxCustomRecordValues"] as CheckBox;

--- a/STROOP/Managers/DisassemblyManager.cs
+++ b/STROOP/Managers/DisassemblyManager.cs
@@ -105,7 +105,7 @@ namespace STROOP.Managers
 
                 // Replace "span's"
                 string searchText = "<span class='dis-reg-";
-                int findIndex = _output.Text.IndexOf(searchText); ;
+                int findIndex = _output.Text.IndexOf(searchText);
                 while (findIndex >= 0) {
                     _output.ReadOnly = false;
                     _output.Select(findIndex, _output.Text.IndexOf('>', findIndex) - findIndex + 1);
@@ -120,7 +120,7 @@ namespace STROOP.Managers
                 }
 
                 searchText = "<span class='dis-address-jump'>";
-                findIndex = _output.Text.IndexOf(searchText); ;
+                findIndex = _output.Text.IndexOf(searchText);
                 while (findIndex >= 0) {
                     _output.ReadOnly = false;
                     _output.Select(findIndex, searchText.Length);

--- a/STROOP/Managers/GfxManager.cs
+++ b/STROOP/Managers/GfxManager.cs
@@ -201,7 +201,7 @@ namespace STROOP.Managers
             // Should only happen when memory is invalid (for example when the US setting is used on a JP ROM)
             if (node == null) return new TreeNode("Invalid Gfx Node"); 
 
-            TreeNode res = new TreeNode(node.Name, node.Children.Select(x => GfxToTreeNode(x)).ToArray());
+            TreeNode res = new TreeNode(node.Name, node.Children.Select(GfxToTreeNode).ToArray());
             res.Tag = node;
             return res;
         }
@@ -351,7 +351,7 @@ namespace STROOP.Managers
             { 0x802771BC, "Mario eyes" },
             { 0x802774F4, "Mario hand" },
             { 0x8029DBD4, "Current room" },
-            { 0x8029DB48, "Fully opaque" },
+            { 0x8029DB48, "Fully opaque" }
             
 
         };
@@ -364,7 +364,7 @@ namespace STROOP.Managers
             { 0x80276C0C, "Mario eyes" },
             { 0x80276F44, "Mario hand" },
             { 0x8029D458, "Current room" },
-            { 0x8029D3CC, "Fully opaque" },
+            { 0x8029D3CC, "Fully opaque" }
         };
 
 
@@ -433,7 +433,7 @@ namespace STROOP.Managers
             { 0x802775CC, "Mario hand / foot scaler"},
             { 0x80277D6C, "Mirror Mario inside out"},
             { 0x80277294, "Mario torso tilter"},
-            { 0x802773A4, "C-up head rotation" },
+            { 0x802773A4, "C-up head rotation" }
         };
 
         public static readonly Dictionary<uint, string> DictionaryJP = new Dictionary<uint, string>
@@ -451,7 +451,7 @@ namespace STROOP.Managers
             { 0x8027701C, "Mario hand / foot scaler"},
             { 0x802777BC, "Mirror Mario inside out"},
             { 0x80276CE4, "Mario torso tilter"},
-            { 0x80276DF4, "C-up head rotation" },
+            { 0x80276DF4, "C-up head rotation" }
         };
 
         public override string Name {

--- a/STROOP/Managers/HudManager.cs
+++ b/STROOP/Managers/HudManager.cs
@@ -41,19 +41,19 @@ namespace STROOP.Managers
 
             ControlUtilities.AddContextMenuStripFunctions(
                 _turnOnOffHudButton,
-                new List<string>()
+                new List<string>
                 {
                     "Disable HUD by Changing Level Index",
                     "Enable HUD by Changing Level Index",
                     "Disable HUD by Removing Function",
-                    "Enable HUD by Removing Function",
+                    "Enable HUD by Removing Function"
                 },
-                new List<Action>()
+                new List<Action>
                 {
                     () => ButtonUtilities.SetHudVisibility(false, true),
                     () => ButtonUtilities.SetHudVisibility(true, true),
                     () => ButtonUtilities.SetHudVisibility(false, false),
-                    () => ButtonUtilities.SetHudVisibility(true, false),
+                    () => ButtonUtilities.SetHudVisibility(true, false)
                 });
 
             _checkBoxFullHP = splitContainerHud.Panel1.Controls["checkBoxFullHP"] as CheckBox;

--- a/STROOP/Managers/InjectionManager.cs
+++ b/STROOP/Managers/InjectionManager.cs
@@ -15,7 +15,7 @@ namespace STROOP.Managers
     public class InjectionManager
     {
         ScriptParser _parser;
-        readonly byte[] byteUintFF = new byte[] { 0xFF, 0xFF, 0xFF, 0xFF };
+        readonly byte[] byteUintFF = { 0xFF, 0xFF, 0xFF, 0xFF };
         CheckBox _useRomHackChecBox;
       
         uint _freeMemPtr;

--- a/STROOP/Managers/MapManager.cs
+++ b/STROOP/Managers/MapManager.cs
@@ -69,7 +69,7 @@ namespace STROOP.Managers
             // Buttons on Options
             ControlUtilities.AddContextMenuStripFunctions(
                 Config.MapGui.buttonMapOptionsAddNewTracker,
-                new List<string>()
+                new List<string>
                 {
                     "Add Tracker for Custom Points",
                     "Add Tracker for Custom Floor Tris",
@@ -83,9 +83,9 @@ namespace STROOP.Managers
                     "Add Tracker for Custom Background",
                     "Add Tracker for Custom Gridlines",
                     "Add Tracker for PU Gridlines",
-                    "Add Tracker for Iwerlipses",
+                    "Add Tracker for Iwerlipses"
                 },
-                new List<Action>()
+                new List<Action>
                 {
                     () =>
                     {
@@ -172,7 +172,7 @@ namespace STROOP.Managers
                         MapObject mapObj = new MapIwerlipsesObject();
                         MapTracker tracker = new MapTracker(mapObj);
                         Config.MapGui.flowLayoutPanelMapTrackers.AddNewControl(tracker);
-                    },
+                    }
                 });
             Config.MapGui.buttonMapOptionsAddNewTracker.Click += (sender, e) =>
                 Config.MapGui.buttonMapOptionsAddNewTracker.ContextMenuStrip.Show(Cursor.Position);
@@ -194,21 +194,21 @@ namespace STROOP.Managers
                 Config.MapGraphics.ChangeScale2(1, Config.MapGui.textBoxMapControllersScaleChange2.Text);
             ControlUtilities.AddContextMenuStripFunctions(
                 Config.MapGui.groupBoxMapControllersScale,
-                new List<string>()
+                new List<string>
                 {
                     "Very Small Unit Squares",
                     "Small Unit Squares",
                     "Medium Unit Squares",
                     "Big Unit Squares",
-                    "Very Big Unit Squares",
+                    "Very Big Unit Squares"
                 },
-                new List<Action>()
+                new List<Action>
                 {
                     () => Config.MapGraphics.SetCustomScale(6),
                     () => Config.MapGraphics.SetCustomScale(12),
                     () => Config.MapGraphics.SetCustomScale(18),
                     () => Config.MapGraphics.SetCustomScale(24),
-                    () => Config.MapGraphics.SetCustomScale(40),
+                    () => Config.MapGraphics.SetCustomScale(40)
                 });
 
             // Buttons for Changing Center
@@ -578,7 +578,7 @@ namespace STROOP.Managers
         {
             // Determine which obj slots have been checked/unchecked since the last update
             List<int> currentObjIndexes = Config.ObjectSlotsManager.SelectedOnMap3SlotsAddresses
-                .ConvertAll(address => ObjectUtilities.GetObjectIndex(address))
+                .ConvertAll(ObjectUtilities.GetObjectIndex)
                 .FindAll(address => address.HasValue)
                 .ConvertAll(address => address.Value);
             List<int> toBeRemovedIndexes = _currentObjIndexes.FindAll(i => !currentObjIndexes.Contains(i));
@@ -600,7 +600,7 @@ namespace STROOP.Managers
                 MapSemaphore semaphore = MapSemaphoreManager.Objects[index];
                 semaphore.IsUsed = true;
                 MapTracker tracker = new MapTracker(
-                    new List<MapObject>() { mapObj }, new List<MapSemaphore>() { semaphore });
+                    new List<MapObject> { mapObj }, new List<MapSemaphore> { semaphore });
                 Config.MapGui.flowLayoutPanelMapTrackers.AddNewControl(tracker);
             }
         }
@@ -623,11 +623,11 @@ namespace STROOP.Managers
 
             // Update object slots when tracker is deleted
             Config.ObjectSlotsManager.SelectedOnMap3SlotsAddresses
-                .ConvertAll(address => ObjectUtilities.GetObjectIndex(address))
+                .ConvertAll(ObjectUtilities.GetObjectIndex)
                 .FindAll(index => index.HasValue)
                 .ConvertAll(index => index.Value)
                 .FindAll(index => !MapSemaphoreManager.Objects[index].IsUsed)
-                .ConvertAll(index => ObjectUtilities.GetObjectAddress(index))
+                .ConvertAll(ObjectUtilities.GetObjectAddress)
                 .ForEach(address => Config.ObjectSlotsManager.SelectedOnMap3SlotsAddresses.Remove(address));
         }
 
@@ -637,7 +637,7 @@ namespace STROOP.Managers
             List<MapObject> mapObjs = addresses
                 .ConvertAll(address => new MapObjectObject(address) as MapObject);
             List<int> indexes = addresses
-                .ConvertAll(address => ObjectUtilities.GetObjectIndex(address))
+                .ConvertAll(ObjectUtilities.GetObjectIndex)
                 .FindAll(index => index.HasValue)
                 .ConvertAll(index => index.Value);
             List<MapSemaphore> semaphores = indexes
@@ -649,31 +649,31 @@ namespace STROOP.Managers
             Config.MapGui.flowLayoutPanelMapTrackers.AddNewControl(tracker);
         }
 
-        private static readonly List<string> inGameColoredVars = new List<string>() { };
-        private static readonly List<string> cameraPosAndFocusColoredVars = new List<string>()
+        private static readonly List<string> inGameColoredVars = new List<string>();
+        private static readonly List<string> cameraPosAndFocusColoredVars = new List<string>
         {
-            "Camera X", "Camera Y", "Camera Z", "Focus X", "Focus Y", "Focus Z", "FOV",
+            "Camera X", "Camera Y", "Camera Z", "Focus X", "Focus Y", "Focus Z", "FOV"
         };
-        private static readonly List<string> cameraPosAndAngleColoredVars = new List<string>()
+        private static readonly List<string> cameraPosAndAngleColoredVars = new List<string>
         {
-            "Camera X", "Camera Y", "Camera Z", "Camera Yaw", "Camera Pitch", "Camera Roll", "FOV",
+            "Camera X", "Camera Y", "Camera Z", "Camera Yaw", "Camera Pitch", "Camera Roll", "FOV"
         };
-        private static readonly List<string> followFocusRelativeAngleColoredVars = new List<string>()
+        private static readonly List<string> followFocusRelativeAngleColoredVars = new List<string>
         {
-            "Focus Pos PA", "Focus Angle PA", "Following Radius", "Following Y Offset", "Following Yaw", "FOV",
+            "Focus Pos PA", "Focus Angle PA", "Following Radius", "Following Y Offset", "Following Yaw", "FOV"
         };
-        private static readonly List<string> followFocusAbsoluteAngleColoredVars = new List<string>()
+        private static readonly List<string> followFocusAbsoluteAngleColoredVars = new List<string>
         {
-            "Focus Pos PA", "Following Radius", "Following Y Offset", "Following Yaw", "FOV",
+            "Focus Pos PA", "Following Radius", "Following Y Offset", "Following Yaw", "FOV"
         };
         private static readonly Dictionary<Map3DCameraMode, List<string>> coloredVarsMap =
-            new Dictionary<Map3DCameraMode, List<string>>()
+            new Dictionary<Map3DCameraMode, List<string>>
             {
                 [Map3DCameraMode.InGame] = inGameColoredVars,
                 [Map3DCameraMode.CameraPosAndFocus] = cameraPosAndFocusColoredVars,
                 [Map3DCameraMode.CameraPosAndAngle] = cameraPosAndAngleColoredVars,
                 [Map3DCameraMode.FollowFocusRelativeAngle] = followFocusRelativeAngleColoredVars,
-                [Map3DCameraMode.FollowFocusAbsoluteAngle] = followFocusAbsoluteAngleColoredVars,
+                [Map3DCameraMode.FollowFocusAbsoluteAngle] = followFocusAbsoluteAngleColoredVars
             };
 
         private void UpdateVarColors()

--- a/STROOP/Managers/MarioManager.cs
+++ b/STROOP/Managers/MarioManager.cs
@@ -15,7 +15,7 @@ namespace STROOP.Managers
     public class MarioManager : DataManager
     {
         private static readonly List<VariableGroup> ALL_VAR_GROUPS =
-            new List<VariableGroup>()
+            new List<VariableGroup>
             {
                 VariableGroup.Basic,
                 VariableGroup.Intermediate,
@@ -23,14 +23,14 @@ namespace STROOP.Managers
                 VariableGroup.HolpMario,
                 VariableGroup.HolpPoint,
                 VariableGroup.Trajectory,
-                VariableGroup.Hacks,
+                VariableGroup.Hacks
             };
 
         private static readonly List<VariableGroup> VISIBLE_VAR_GROUPS =
-            new List<VariableGroup>()
+            new List<VariableGroup>
             {
                 VariableGroup.Basic,
-                VariableGroup.Intermediate,
+                VariableGroup.Intermediate
             };
 
         public MarioManager(string varFilePath, Control marioControl, WatchVariableFlowLayoutPanel variableTable)
@@ -102,59 +102,47 @@ namespace STROOP.Managers
                 marioSlidingSpeedGroupBox.Controls["buttonMarioSlidingSpeedXn"] as Button,
                 marioSlidingSpeedGroupBox.Controls["buttonMarioSlidingSpeedXp"] as Button,
                 marioSlidingSpeedGroupBox.Controls["textBoxMarioSlidingSpeedX"] as TextBox,
-                (float value) =>
-                {
-                    ButtonUtilities.MarioChangeSlidingSpeedX(value);
-                });
+                ButtonUtilities.MarioChangeSlidingSpeedX);
             ControlUtilities.InitializeScalarController(
                 marioSlidingSpeedGroupBox.Controls["buttonMarioSlidingSpeedZn"] as Button,
                 marioSlidingSpeedGroupBox.Controls["buttonMarioSlidingSpeedZp"] as Button,
                 marioSlidingSpeedGroupBox.Controls["textBoxMarioSlidingSpeedZ"] as TextBox,
-                (float value) =>
-                {
-                    ButtonUtilities.MarioChangeSlidingSpeedZ(value);
-                });
+                ButtonUtilities.MarioChangeSlidingSpeedZ);
             ControlUtilities.InitializeScalarController(
                 marioSlidingSpeedGroupBox.Controls["buttonMarioSlidingSpeedHn"] as Button,
                 marioSlidingSpeedGroupBox.Controls["buttonMarioSlidingSpeedHp"] as Button,
                 marioSlidingSpeedGroupBox.Controls["textBoxMarioSlidingSpeedH"] as TextBox,
-                (float value) =>
-                {
-                    ButtonUtilities.MarioChangeSlidingSpeedH(value);
-                });
+                ButtonUtilities.MarioChangeSlidingSpeedH);
             ControlUtilities.InitializeScalarController(
                 marioSlidingSpeedGroupBox.Controls["buttonMarioSlidingSpeedYawN"] as Button,
                 marioSlidingSpeedGroupBox.Controls["buttonMarioSlidingSpeedYawP"] as Button,
                 marioSlidingSpeedGroupBox.Controls["textBoxMarioSlidingSpeedYaw"] as TextBox,
-                (float value) =>
-                {
-                    ButtonUtilities.MarioChangeSlidingSpeedYaw(value);
-                });
+                ButtonUtilities.MarioChangeSlidingSpeedYaw);
 
             Button buttonMarioHOLPGoto = splitContainerMario.Panel1.Controls["buttonMarioHOLPGoto"] as Button;
             buttonMarioHOLPGoto.Click += (sender, e) => ButtonUtilities.GotoHOLP();
             ControlUtilities.AddContextMenuStripFunctions(
                 buttonMarioHOLPGoto,
-                new List<string>() { "Goto HOLP", "Goto HOLP Laterally", "Goto HOLP X", "Goto HOLP Y", "Goto HOLP Z" },
-                new List<Action>() {
+                new List<string> { "Goto HOLP", "Goto HOLP Laterally", "Goto HOLP X", "Goto HOLP Y", "Goto HOLP Z" },
+                new List<Action> {
                     () => ButtonUtilities.GotoHOLP((true, true, true)),
                     () => ButtonUtilities.GotoHOLP((true, false, true)),
                     () => ButtonUtilities.GotoHOLP((true, false, false)),
                     () => ButtonUtilities.GotoHOLP((false, true, false)),
-                    () => ButtonUtilities.GotoHOLP((false, false, true)),
+                    () => ButtonUtilities.GotoHOLP((false, false, true))
                 });
 
             Button buttonMarioHOLPRetrieve = splitContainerMario.Panel1.Controls["buttonMarioHOLPRetrieve"] as Button;
             buttonMarioHOLPRetrieve.Click += (sender, e) => ButtonUtilities.RetrieveHOLP();
             ControlUtilities.AddContextMenuStripFunctions(
                 buttonMarioHOLPRetrieve,
-                new List<string>() { "Retrieve HOLP", "Retrieve HOLP Laterally", "Retrieve HOLP X", "Retrieve HOLP Y", "Retrieve HOLP Z" },
-                new List<Action>() {
+                new List<string> { "Retrieve HOLP", "Retrieve HOLP Laterally", "Retrieve HOLP X", "Retrieve HOLP Y", "Retrieve HOLP Z" },
+                new List<Action> {
                     () => ButtonUtilities.RetrieveHOLP((true, true, true)),
                     () => ButtonUtilities.RetrieveHOLP((true, false, true)),
                     () => ButtonUtilities.RetrieveHOLP((true, false, false)),
                     () => ButtonUtilities.RetrieveHOLP((false, true, false)),
-                    () => ButtonUtilities.RetrieveHOLP((false, false, true)),
+                    () => ButtonUtilities.RetrieveHOLP((false, false, true))
                 });
 
             var marioHOLPGroupBox = splitContainerMario.Panel1.Controls["groupBoxMarioHOLP"] as GroupBox;

--- a/STROOP/Managers/MemoryManager.cs
+++ b/STROOP/Managers/MemoryManager.cs
@@ -157,7 +157,7 @@ namespace STROOP.Managers
             Action<bool> pasteAction = (bool spareSecondary) =>
             {
                 if (!Address.HasValue || _objectSnapshot == null) return;
-                List<uint> addresses = new List<uint>() { Address.Value };
+                List<uint> addresses = new List<uint> { Address.Value };
                 if (KeyboardUtilities.IsCtrlHeld())
                 {
                     addresses = Config.ObjectSlotsManager.SelectedObjects.ConvertAll(obj => obj.Address);
@@ -167,15 +167,15 @@ namespace STROOP.Managers
             _buttonMemoryPasteObject.Click += (sender, e) => pasteAction(false);
             ControlUtilities.AddContextMenuStripFunctions(
                 _buttonMemoryPasteObject,
-                new List<string>()
+                new List<string>
                 {
                     "Paste Object without Primary Variables",
-                    "Paste Object without Secondary Variables",
+                    "Paste Object without Secondary Variables"
                 },
-                new List<Action>()
+                new List<Action>
                 {
                     () => pasteAction(false),
-                    () => pasteAction(true),
+                    () => pasteAction(true)
                 });
 
             _buttonMemoryMoveUpOnce.Click += (sender, e) => ScrollMemory(-1);
@@ -275,7 +275,7 @@ namespace STROOP.Managers
             if (isAltKeyHeld)
             {
                 List<List<WatchVariableControlPrecursor>> precursorLists =
-                    new List<List<WatchVariableControlPrecursor>>()
+                    new List<List<WatchVariableControlPrecursor>>
                         { _objectPrecursors, _objectSpecificPrecursors };
                 _currentValueTexts.ForEach(valueText =>
                     valueText.AddOverlappedIfSelected(index, precursorLists));
@@ -363,7 +363,7 @@ namespace STROOP.Managers
                     List<WatchVariableControlPrecursor> overlapped = GetOverlapped(precursors);
                     overlapped.ForEach(precursor => Config.MemoryManager.AddVariable(
                         precursor.CreateWatchVariableControl(
-                            newVariableGroupList: new List<VariableGroup>() { VariableGroup.Custom })));
+                            newVariableGroupList: new List<VariableGroup> { VariableGroup.Custom })));
                 });
             }
 

--- a/STROOP/Managers/MiscManager.cs
+++ b/STROOP/Managers/MiscManager.cs
@@ -17,20 +17,20 @@ namespace STROOP.Managers
         CheckBox _checkBoxTurnOffMusic;
 
         private static readonly List<VariableGroup> ALL_VAR_GROUPS =
-            new List<VariableGroup>()
+            new List<VariableGroup>
             {
                 VariableGroup.Basic,
                 VariableGroup.Intermediate,
                 VariableGroup.Advanced,
-                VariableGroup.Coin,
+                VariableGroup.Coin
             };
 
         private static readonly List<VariableGroup> VISIBLE_VAR_GROUPS =
-            new List<VariableGroup>()
+            new List<VariableGroup>
             {
                 VariableGroup.Basic,
                 VariableGroup.Intermediate,
-                VariableGroup.Advanced,
+                VariableGroup.Advanced
             };
 
         public MiscManager(string varFilePath, WatchVariableFlowLayoutPanel variableTable, Control miscControl)
@@ -66,7 +66,7 @@ namespace STROOP.Managers
             buttonMiscGoToCourse.Click += (sender, e) => buttonMiscGoToCourse.ContextMenuStrip.Show(Cursor.Position);
         }
 
-        private static readonly List<CourseToGoTo> _coursesToGoTo = new List<CourseToGoTo>()
+        private static readonly List<CourseToGoTo> _coursesToGoTo = new List<CourseToGoTo>
         {
             new CourseToGoTo(09, "Bob-omb Battlefield"),
             new CourseToGoTo(24, "Whomp's Fortress"),
@@ -103,7 +103,7 @@ namespace STROOP.Managers
             new CourseToGoTo(16, "Castle Grounds"),
             new CourseToGoTo(26, "Castle Courtyard"),
 
-            new CourseToGoTo(25, "Ending Cutscene"),
+            new CourseToGoTo(25, "Ending Cutscene")
         };
 
         private class CourseToGoTo

--- a/STROOP/Managers/ModelManager.cs
+++ b/STROOP/Managers/ModelManager.cs
@@ -200,7 +200,7 @@ namespace STROOP.Managers
                 short y = Config.Stream.GetInt16(modelPtr + 0x02);
                 short z = Config.Stream.GetInt16(modelPtr + 0x04);
                 modelPtr += 0x06;
-                vertices.Add(new short[3] { x, y, z });
+                vertices.Add(new short[] { x, y, z });
             }
 
             return vertices;

--- a/STROOP/Managers/ObjectManager.cs
+++ b/STROOP/Managers/ObjectManager.cs
@@ -98,7 +98,7 @@ namespace STROOP.Managers
             }
             set
             {
-                if (_objectNameTextBox.Text != value)
+                if (_objectNameTextBox.Text != value) // this seems redundant
                     _objectNameTextBox.Text = value;
             }
         }
@@ -127,7 +127,7 @@ namespace STROOP.Managers
             }
             set
             {
-                if (_objectImagePictureBox.Image != value)
+                if (_objectImagePictureBox.Image != value) // this seems redundant
                     _objectImagePictureBox.Image = value;
             }
         }
@@ -143,7 +143,7 @@ namespace STROOP.Managers
         }
 
         private static readonly List<VariableGroup> ALL_VAR_GROUPS =
-            new List<VariableGroup>()
+            new List<VariableGroup>
             {
                 VariableGroup.Basic,
                 VariableGroup.Intermediate,
@@ -153,15 +153,15 @@ namespace STROOP.Managers
                 VariableGroup.Collision,
                 VariableGroup.Movement,
                 VariableGroup.Transformation,
-                VariableGroup.Coordinate,
+                VariableGroup.Coordinate
             };
 
         private static readonly List<VariableGroup> VISIBLE_VAR_GROUPS =
-            new List<VariableGroup>()
+            new List<VariableGroup>
             {
                 VariableGroup.Basic,
                 VariableGroup.Intermediate,
-                VariableGroup.ObjectSpecific,
+                VariableGroup.ObjectSpecific
             };
 
         public ObjectManager(string varFilePath, Control objectControl, WatchVariableFlowLayoutPanel variableTable)
@@ -188,52 +188,52 @@ namespace STROOP.Managers
             goToButton.Click += (sender, e) => ButtonUtilities.GotoObjects(_objects);
             ControlUtilities.AddContextMenuStripFunctions(
                 goToButton,
-                new List<string>() { "Goto", "Goto Laterally", "Goto X", "Goto Y", "Goto Z" },
-                new List<Action>() {
+                new List<string> { "Goto", "Goto Laterally", "Goto X", "Goto Y", "Goto Z" },
+                new List<Action> {
                     () => ButtonUtilities.GotoObjects(_objects, (true, true, true)),
                     () => ButtonUtilities.GotoObjects(_objects, (true, false, true)),
                     () => ButtonUtilities.GotoObjects(_objects, (true, false, false)),
                     () => ButtonUtilities.GotoObjects(_objects, (false, true, false)),
-                    () => ButtonUtilities.GotoObjects(_objects, (false, false, true)),
+                    () => ButtonUtilities.GotoObjects(_objects, (false, false, true))
                 });
 
             var retrieveButton = objPanel.Controls["buttonObjRetrieve"] as Button;
             retrieveButton.Click += (sender, e) => ButtonUtilities.RetrieveObjects(_objects);
             ControlUtilities.AddContextMenuStripFunctions(
                 retrieveButton,
-                new List<string>() { "Retrieve", "Retrieve Laterally", "Retrieve X", "Retrieve Y", "Retrieve Z" },
-                new List<Action>() {
+                new List<string> { "Retrieve", "Retrieve Laterally", "Retrieve X", "Retrieve Y", "Retrieve Z" },
+                new List<Action> {
                     () => ButtonUtilities.RetrieveObjects(_objects, (true, true, true)),
                     () => ButtonUtilities.RetrieveObjects(_objects, (true, false, true)),
                     () => ButtonUtilities.RetrieveObjects(_objects, (true, false, false)),
                     () => ButtonUtilities.RetrieveObjects(_objects, (false, true, false)),
-                    () => ButtonUtilities.RetrieveObjects(_objects, (false, false, true)),
+                    () => ButtonUtilities.RetrieveObjects(_objects, (false, false, true))
                 });
 
             var goToHomeButton = objPanel.Controls["buttonObjGotoHome"] as Button;
             goToHomeButton.Click += (sender, e) => ButtonUtilities.GotoObjectsHome(_objects);
             ControlUtilities.AddContextMenuStripFunctions(
                 goToHomeButton,
-                new List<string>() { "Goto Home", "Goto Home Laterally", "Goto Home X", "Goto Home Y", "Goto Home Z" },
-                new List<Action>() {
+                new List<string> { "Goto Home", "Goto Home Laterally", "Goto Home X", "Goto Home Y", "Goto Home Z" },
+                new List<Action> {
                     () => ButtonUtilities.GotoObjectsHome(_objects, (true, true, true)),
                     () => ButtonUtilities.GotoObjectsHome(_objects, (true, false, true)),
                     () => ButtonUtilities.GotoObjectsHome(_objects, (true, false, false)),
                     () => ButtonUtilities.GotoObjectsHome(_objects, (false, true, false)),
-                    () => ButtonUtilities.GotoObjectsHome(_objects, (false, false, true)),
+                    () => ButtonUtilities.GotoObjectsHome(_objects, (false, false, true))
                 });
 
             var retrieveHomeButton = objPanel.Controls["buttonObjRetrieveHome"] as Button;
             retrieveHomeButton.Click += (sender, e) => ButtonUtilities.RetrieveObjectsHome(_objects);
             ControlUtilities.AddContextMenuStripFunctions(
                 retrieveHomeButton,
-                new List<string>() { "Retrieve Home", "Retrieve Home Laterally", "Retrieve Home X", "Retrieve Home Y", "Retrieve Home Z" },
-                new List<Action>() {
+                new List<string> { "Retrieve Home", "Retrieve Home Laterally", "Retrieve Home X", "Retrieve Home Y", "Retrieve Home Z" },
+                new List<Action> {
                     () => ButtonUtilities.RetrieveObjectsHome(_objects, (true, true, true)),
                     () => ButtonUtilities.RetrieveObjectsHome(_objects, (true, false, true)),
                     () => ButtonUtilities.RetrieveObjectsHome(_objects, (true, false, false)),
                     () => ButtonUtilities.RetrieveObjectsHome(_objects, (false, true, false)),
-                    () => ButtonUtilities.RetrieveObjectsHome(_objects, (false, false, true)),
+                    () => ButtonUtilities.RetrieveObjectsHome(_objects, (false, false, true))
                 });
 
             _releaseButton = objPanel.Controls["buttonObjRelease"] as BinaryButton;
@@ -247,11 +247,11 @@ namespace STROOP.Managers
                     || o.ReleaseStatus == ObjectConfig.ReleaseStatusDroppedValue));
             ControlUtilities.AddContextMenuStripFunctions(
                 _releaseButton,
-                new List<string>() { "Release by Throwing", "Release by Dropping", "UnRelease" },
-                new List<Action>() {
+                new List<string> { "Release by Throwing", "Release by Dropping", "UnRelease" },
+                new List<Action> {
                     () => ButtonUtilities.ReleaseObject(_objects, true),
                     () => ButtonUtilities.ReleaseObject(_objects, false),
-                    () => ButtonUtilities.UnReleaseObject(_objects),
+                    () => ButtonUtilities.UnReleaseObject(_objects)
                 });
 
             _interactButton = objPanel.Controls["buttonObjInteract"] as BinaryButton;
@@ -263,10 +263,10 @@ namespace STROOP.Managers
                 () => _objects.Count > 0 && _objects.All(o => o.InteractionStatus != 0));
             ControlUtilities.AddContextMenuStripFunctions(
                 _interactButton,
-                new List<string>() { "Interact", "UnInteract" },
-                new List<Action>() {
+                new List<string> { "Interact", "UnInteract" },
+                new List<Action> {
                     () => ButtonUtilities.InteractObject(_objects),
-                    () => ButtonUtilities.UnInteractObject(_objects),
+                    () => ButtonUtilities.UnInteractObject(_objects)
                 });
 
             _cloneButton = objPanel.Controls["buttonObjClone"] as BinaryButton;
@@ -278,17 +278,17 @@ namespace STROOP.Managers
                 () => _objects.Count > 0 && _objects.FirstOrDefault().Address == DataModels.Mario.HeldObject);
             ControlUtilities.AddContextMenuStripFunctions(
                 _cloneButton,
-                new List<string>() {
+                new List<string> {
                     "Clone with Action Update",
                     "Clone without Action Update",
                     "UnClone with Action Update",
-                    "UnClone without Action Update",
+                    "UnClone without Action Update"
                 },
-                new List<Action>() {
+                new List<Action> {
                     () => ButtonUtilities.CloneObject(_objects.FirstOrDefault(), true),
                     () => ButtonUtilities.CloneObject(_objects.FirstOrDefault(), false),
                     () => ButtonUtilities.UnCloneObject(true),
-                    () => ButtonUtilities.UnCloneObject(false),
+                    () => ButtonUtilities.UnCloneObject(false)
                 });
 
             _unloadButton = objPanel.Controls["buttonObjUnload"] as BinaryButton;
@@ -300,10 +300,10 @@ namespace STROOP.Managers
                 () => _objects.Count > 0 && _objects.All(o => !o.IsActive));
             ControlUtilities.AddContextMenuStripFunctions(
                 _unloadButton,
-                new List<string>() { "Unload", "Revive" },
-                new List<Action>() {
+                new List<string> { "Unload", "Revive" },
+                new List<Action> {
                     () => ButtonUtilities.UnloadObject(_objects),
-                    () => ButtonUtilities.ReviveObject(_objects),
+                    () => ButtonUtilities.ReviveObject(_objects)
                 });
 
             _rideButton = objPanel.Controls["buttonObjRide"] as BinaryButton;
@@ -315,18 +315,19 @@ namespace STROOP.Managers
                 () => _objects.Count > 0 && _objects.FirstOrDefault().Address == DataModels.Mario.RiddenObject);
             ControlUtilities.AddContextMenuStripFunctions(
                 _rideButton,
-                new List<string>() {
+                new List<string> {
                     "Ride with Action Update",
                     "Ride without Action Update",
                     "UnRide with Action Update",
-                    "UnRide without Action Update",
+                    "UnRide without Action Update"
                 },
-                new List<Action>() {
+                new List<Action> {
                     () => ButtonUtilities.RideObject(_objects.FirstOrDefault(), true),
                     () => ButtonUtilities.RideObject(_objects.FirstOrDefault(), false),
                     () => ButtonUtilities.UnRideObject(true),
-                    () => ButtonUtilities.UnRideObject(false),
-        });
+                    () => ButtonUtilities.UnRideObject(false)
+                }
+            );
 
             Button ukikipediaButton = objPanel.Controls["buttonObjUkikipedia"] as Button;
             ukikipediaButton.Click += (sender, e) => ButtonUtilities.UkikipediaObject(_objects.FirstOrDefault());

--- a/STROOP/Managers/ObjectSlotsManager.cs
+++ b/STROOP/Managers/ObjectSlotsManager.cs
@@ -71,7 +71,7 @@ namespace STROOP.Managers
                 objectSlot.Click += (sender, e) => OnSlotClick(sender, e);
                 ObjectSlots.Add(objectSlot);
                 _gui.FlowLayoutContainer.Controls.Add(objectSlot);
-            };
+            }
 
             SlotLabelsForObjects = new ReadOnlyDictionary<ObjectDataModel, string>(_slotLabels);
         }
@@ -82,7 +82,7 @@ namespace STROOP.Managers
                 objSlot.Size = new Size(newSize, newSize);
         }
 
-        private static readonly Dictionary<string, TabType> TabNameToTabType = new Dictionary<string, TabType>()
+        private static readonly Dictionary<string, TabType> TabNameToTabType = new Dictionary<string, TabType>
         {
             ["Object"] = TabType.Object,
             ["Map"] = TabType.Map,
@@ -90,7 +90,7 @@ namespace STROOP.Managers
             ["Memory"] = TabType.Memory,
             ["Custom"] = TabType.Custom,
             ["TAS"] = TabType.TAS,
-            ["Cam Hack"] = TabType.CamHack,
+            ["Cam Hack"] = TabType.CamHack
         };
         private void TabControl_Selected(object sender, TabControlEventArgs e)
         {
@@ -307,7 +307,7 @@ namespace STROOP.Managers
                     sortedObjects = activeObjects.Concat(inActiveObjects);
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException("Uknown sort method type");
+                    throw new ArgumentOutOfRangeException("Unknown sort method type");
             }
 
             // Update slots

--- a/STROOP/Managers/OptionsManager.cs
+++ b/STROOP/Managers/OptionsManager.cs
@@ -20,7 +20,7 @@ namespace STROOP.Managers
 
         public OptionsManager(TabPage tabControl, Control cogControl)
         {
-            _savedSettingsTextList = new List<string>()
+            _savedSettingsTextList = new List<string>
             {
                 "Display Yaw Angles as Unsigned",
                 "Variable Values Flush Right",
@@ -34,10 +34,10 @@ namespace STROOP.Managers
                 "Display as Hex Uses Memory",
                 "Neutralize Triangles with 0x15",
                 "Cloning Updates Holp Type",
-                "Use In-Game Trig for Angle Logic",
+                "Use In-Game Trig for Angle Logic"
             };
 
-            _savedSettingsGetterList = new List<Func<bool>>()
+            _savedSettingsGetterList = new List<Func<bool>>
             {
                 () => SavedSettingsConfig.DisplayYawAnglesAsUnsigned,
                 () => SavedSettingsConfig.VariableValuesFlushRight,
@@ -51,10 +51,10 @@ namespace STROOP.Managers
                 () => SavedSettingsConfig.DisplayAsHexUsesMemory,
                 () => SavedSettingsConfig.NeutralizeTrianglesWith0x15,
                 () => SavedSettingsConfig.CloningUpdatesHolpType,
-                () => SavedSettingsConfig.UseInGameTrigForAngleLogic,
+                () => SavedSettingsConfig.UseInGameTrigForAngleLogic
             };
 
-            _savedSettingsSetterList = new List<Action<bool>>()
+            _savedSettingsSetterList = new List<Action<bool>>
             {
                 (bool value) => SavedSettingsConfig.DisplayYawAnglesAsUnsigned = value,
                 (bool value) => SavedSettingsConfig.VariableValuesFlushRight = value,
@@ -68,7 +68,7 @@ namespace STROOP.Managers
                 (bool value) => SavedSettingsConfig.DisplayAsHexUsesMemory = value,
                 (bool value) => SavedSettingsConfig.NeutralizeTrianglesWith0x15 = value,
                 (bool value) => SavedSettingsConfig.CloningUpdatesHolpType = value,
-                (bool value) => SavedSettingsConfig.UseInGameTrigForAngleLogic = value,
+                (bool value) => SavedSettingsConfig.UseInGameTrigForAngleLogic = value
             };
 
             _savedSettingsCheckedListBox = tabControl.Controls["checkedListBoxSavedSettings"] as CheckedListBox;
@@ -147,8 +147,7 @@ namespace STROOP.Managers
                 groupBoxPositionControllerRelativeAngle.Controls["textBoxPositionControllerRelativeAngleCustom"] as BetterTextbox;
             textBoxPositionControllerRelativeAngleCustom.LostFocus += (sender, e) =>
             {
-                double value;
-                if (double.TryParse((sender as TextBox).Text, out value))
+                if (double.TryParse((sender as TextBox).Text, out double value))
                 {
                     PositionControllerRelativityConfig.CustomAngle = value;
                 }
@@ -159,7 +158,7 @@ namespace STROOP.Managers
             };
 
             // object slot overlays
-            List<string> objectSlotOverlayTextList = new List<string>()
+            List<string> objectSlotOverlayTextList = new List<string>
             {
                 "Held Object",
                 "Stood On Object",
@@ -174,10 +173,10 @@ namespace STROOP.Managers
                 "Ceiling Object",
                 "Collision Object",
                 "Parent Object",
-                "Child Object",
+                "Child Object"
             };
 
-            List<Func<bool>> objectSlotOverlayGetterList = new List<Func<bool>>()
+            List<Func<bool>> objectSlotOverlayGetterList = new List<Func<bool>>
             {
                 () => OverlayConfig.ShowOverlayHeldObject,
                 () => OverlayConfig.ShowOverlayStoodOnObject,
@@ -192,10 +191,10 @@ namespace STROOP.Managers
                 () => OverlayConfig.ShowOverlayCeilingObject,
                 () => OverlayConfig.ShowOverlayCollisionObject,
                 () => OverlayConfig.ShowOverlayParentObject,
-                () => OverlayConfig.ShowOverlayChildObject,
+                () => OverlayConfig.ShowOverlayChildObject
             };
 
-            List<Action<bool>> objectSlotOverlaySetterList = new List<Action<bool>>()
+            List<Action<bool>> objectSlotOverlaySetterList = new List<Action<bool>>
             {
                 (bool value) => OverlayConfig.ShowOverlayHeldObject = value,
                 (bool value) => OverlayConfig.ShowOverlayStoodOnObject = value,
@@ -210,7 +209,7 @@ namespace STROOP.Managers
                 (bool value) => OverlayConfig.ShowOverlayCeilingObject = value,
                 (bool value) => OverlayConfig.ShowOverlayCollisionObject = value,
                 (bool value) => OverlayConfig.ShowOverlayParentObject = value,
-                (bool value) => OverlayConfig.ShowOverlayChildObject = value,
+                (bool value) => OverlayConfig.ShowOverlayChildObject = value
             };
 
             CheckedListBox checkedListBoxObjectSlotOverlaysToShow = tabControl.Controls["checkedListBoxObjectSlotOverlaysToShow"] as CheckedListBox;
@@ -234,11 +233,11 @@ namespace STROOP.Managers
             };
             ControlUtilities.AddContextMenuStripFunctions(
                 checkedListBoxObjectSlotOverlaysToShow,
-                new List<string>() { "Set All On", "Set All Off" },
-                new List<Action>()
+                new List<string> { "Set All On", "Set All Off" },
+                new List<Action>
                 {
                     () => setAllObjectSlotOverlays(true),
-                    () => setAllObjectSlotOverlays(false),
+                    () => setAllObjectSlotOverlays(false)
                 });
 
             // FPS
@@ -247,8 +246,7 @@ namespace STROOP.Managers
             betterTextboxFPS.AddLostFocusAction(
                 () =>
                 {
-                    uint value;
-                    if (uint.TryParse(betterTextboxFPS.Text, out value))
+                    if (uint.TryParse(betterTextboxFPS.Text, out uint value))
                     {
                         RefreshRateConfig.RefreshRateFreq = value;
                     }

--- a/STROOP/Managers/PaintingManager.cs
+++ b/STROOP/Managers/PaintingManager.cs
@@ -37,8 +37,8 @@ namespace STROOP.Managers
             }
         }
 
-        private List<PaintingData> paintingDataList =
-            new List<PaintingData>()
+        private readonly List<PaintingData> paintingDataList =
+            new List<PaintingData>
             {
                 new PaintingData("BoB", PaintingListTypeEnum.Castle, 0),
                 new PaintingData("WF", PaintingListTypeEnum.Castle, 2),
@@ -55,7 +55,7 @@ namespace STROOP.Managers
                 new PaintingData("THI Tiny", PaintingListTypeEnum.Castle, 9),
                 new PaintingData("THI Huge", PaintingListTypeEnum.Castle, 13),
                 new PaintingData("TTC", PaintingListTypeEnum.Castle, 11),
-                new PaintingData("CotMC", PaintingListTypeEnum.HMC, 0),
+                new PaintingData("CotMC", PaintingListTypeEnum.HMC, 0)
             };
 
         private ListBox _listBoxPainting;

--- a/STROOP/Managers/PuManager.cs
+++ b/STROOP/Managers/PuManager.cs
@@ -16,19 +16,19 @@ namespace STROOP.Managers
         GroupBox _puController;
 
         private static readonly List<VariableGroup> ALL_VAR_GROUPS =
-            new List<VariableGroup>()
+            new List<VariableGroup>
             {
                 VariableGroup.Basic,
                 VariableGroup.Intermediate,
-                VariableGroup.Advanced,
+                VariableGroup.Advanced
             };
 
         private static readonly List<VariableGroup> VISIBLE_VAR_GROUPS =
-            new List<VariableGroup>()
+            new List<VariableGroup>
             {
                 VariableGroup.Basic,
                 VariableGroup.Intermediate,
-                VariableGroup.Advanced,
+                VariableGroup.Advanced
             };
 
         public PuManager(string varFilePath, TabPage tabControl, WatchVariableFlowLayoutPanel watchVariablePanel)

--- a/STROOP/Managers/SnowManager.cs
+++ b/STROOP/Managers/SnowManager.cs
@@ -15,21 +15,21 @@ namespace STROOP.Managers
     public class SnowManager : DataManager
     {
         private static readonly List<VariableGroup> ALL_VAR_GROUPS =
-            new List<VariableGroup>()
+            new List<VariableGroup>
             {
                 VariableGroup.Basic,
                 VariableGroup.Intermediate,
                 VariableGroup.Advanced,
-                VariableGroup.Snow,
+                VariableGroup.Snow
             };
 
         private static readonly List<VariableGroup> VISIBLE_VAR_GROUPS =
-            new List<VariableGroup>()
+            new List<VariableGroup>
             {
                 VariableGroup.Basic,
                 VariableGroup.Intermediate,
                 VariableGroup.Advanced,
-                VariableGroup.Snow,
+                VariableGroup.Snow
             };
 
         private short _numSnowParticles;
@@ -91,17 +91,17 @@ namespace STROOP.Managers
         private List<WatchVariableControl> GetSnowParticleControls(int index)
         {
             uint structOffset = (uint)index * SnowConfig.ParticleStructSize;
-            List<uint> offsets = new List<uint>()
+            List<uint> offsets = new List<uint>
             {
                 structOffset + SnowConfig.XOffset,
                 structOffset + SnowConfig.YOffset,
-                structOffset + SnowConfig.ZOffset,
+                structOffset + SnowConfig.ZOffset
             };
-            List<string> names = new List<string>()
+            List<string> names = new List<string>
             {
                 String.Format("Particle {0} X", index),
                 String.Format("Particle {0} Y", index),
-                String.Format("Particle {0} Z", index),
+                String.Format("Particle {0} Z", index)
             };
 
             List<WatchVariableControl> controls = new List<WatchVariableControl>();

--- a/STROOP/Managers/SoundManager.cs
+++ b/STROOP/Managers/SoundManager.cs
@@ -69,7 +69,7 @@ namespace STROOP.Managers
             if (!updateView) return;
         }
 
-        private List<uint> _soundEffects = new List<uint>()
+        private readonly List<uint> _soundEffects = new List<uint>
         {
             0x0400,
             0x0408,
@@ -620,7 +620,7 @@ namespace STROOP.Managers
             0x9066,
             0x9067,
             0x9069,
-            0x906B,
+            0x906B
         };
     }
 }

--- a/STROOP/Managers/TasManager.cs
+++ b/STROOP/Managers/TasManager.cs
@@ -326,7 +326,7 @@ namespace STROOP.Managers
         private void SetTtcReentrySchedule()
         {
             Dictionary<uint, (double, double, double, double, List<double>)> schedule =
-                new Dictionary<uint, (double, double, double, double, List<double>)>(
+                new Dictionary<uint, (double, double, double, double, List<double>)>
                 {
                     [43816] = (-1378.91674804688f, -2434f, -1423.35168457031f, 39648, new List<double>()),
                     [43817] = (-1305.64807128906f, -2414f, -1353.34362792969f, 39648, new List<double>()),

--- a/STROOP/Managers/TasManager.cs
+++ b/STROOP/Managers/TasManager.cs
@@ -37,22 +37,22 @@ namespace STROOP.Managers
         private static readonly int TABLE_INDEX_Y_INPUT = 7;
 
         private static readonly List<VariableGroup> ALL_VAR_GROUPS =
-            new List<VariableGroup>()
+            new List<VariableGroup>
             {
                 VariableGroup.Basic,
                 VariableGroup.Advanced,
                 VariableGroup.TAS,
                 VariableGroup.Point,
-                VariableGroup.Scheduler,
+                VariableGroup.Scheduler
             };
 
         private static readonly List<VariableGroup> VISIBLE_VAR_GROUPS =
-            new List<VariableGroup>()
+            new List<VariableGroup>
             {
                 VariableGroup.Basic,
                 VariableGroup.Advanced,
                 VariableGroup.Point,
-                VariableGroup.Scheduler,
+                VariableGroup.Scheduler
             };
 
         public TasManager(string varFilePath, TabPage tabControl, WatchVariableFlowLayoutPanel watchVariablePanel)
@@ -70,7 +70,7 @@ namespace STROOP.Managers
             buttonTasStorePosition.Click += (sender, e) => StoreInfo(x: true, y: true, z: true);
             ControlUtilities.AddContextMenuStripFunctions(
                 buttonTasStorePosition,
-                new List<string>()
+                new List<string>
                 {
                     "Store Position",
                     "Store Lateral Position",
@@ -78,9 +78,9 @@ namespace STROOP.Managers
                     "Store Y",
                     "Store Z",
                     "Go to Closest Floor Vertex",
-                    "Go to Closest Floor Vertex Misalignment",
+                    "Go to Closest Floor Vertex Misalignment"
                 },
-                new List<Action>()
+                new List<Action>
                 {
                     () => StoreInfo(x: true, y: true, z: true),
                     () => StoreInfo(x: true, z: true),
@@ -88,7 +88,7 @@ namespace STROOP.Managers
                     () => StoreInfo(y: true),
                     () => StoreInfo(z: true),
                     () => ButtonUtilities.GotoTriangleVertexClosest(Config.Stream.GetUInt32(MarioConfig.StructAddress + MarioConfig.FloorTriangleOffset), false),
-                    () => ButtonUtilities.GotoTriangleVertexClosest(Config.Stream.GetUInt32(MarioConfig.StructAddress + MarioConfig.FloorTriangleOffset), true),
+                    () => ButtonUtilities.GotoTriangleVertexClosest(Config.Stream.GetUInt32(MarioConfig.StructAddress + MarioConfig.FloorTriangleOffset), true)
                 });
 
             Button buttonTasStoreAngle = splitContainerTasTable.Panel1.Controls["buttonTasStoreAngle"] as Button;
@@ -98,13 +98,13 @@ namespace STROOP.Managers
             buttonTasTakePosition.Click += (sender, e) => TakeInfo(x: true, y: true, z: true);
             ControlUtilities.AddContextMenuStripFunctions(
                 buttonTasTakePosition,
-                new List<string>() { "Take Position", "Take Lateral Position", "Take X", "Take Y", "Take Z" },
-                new List<Action>() {
+                new List<string> { "Take Position", "Take Lateral Position", "Take X", "Take Y", "Take Z" },
+                new List<Action> {
                     () => TakeInfo(x: true, y: true, z: true),
                     () => TakeInfo(x: true, z: true),
                     () => TakeInfo(x: true),
                     () => TakeInfo(y: true),
-                    () => TakeInfo(z: true),
+                    () => TakeInfo(z: true)
                 });
 
             Button buttonTasTakeMarioAngle = splitContainerTasTable.Panel1.Controls["buttonTasTakeAngle"] as Button;
@@ -114,8 +114,8 @@ namespace STROOP.Managers
             buttonTasPasteSchedule.Click += (sender, e) => SetScheduler(Clipboard.GetText(), false);
             ControlUtilities.AddContextMenuStripFunctions(
                 buttonTasPasteSchedule,
-                new List<string>() { "Paste Schedule as Floats", "TTC Reentry Schedule" },
-                new List<Action>() { () => SetScheduler(Clipboard.GetText(), true), () => SetTtcReentrySchedule() });
+                new List<string> { "Paste Schedule as Floats", "TTC Reentry Schedule" },
+                new List<Action> { () => SetScheduler(Clipboard.GetText(), true), SetTtcReentrySchedule });
 
             _waitingGlobalTimer = 0;
             _waitingDateTime = DateTime.Now;
@@ -215,9 +215,9 @@ namespace STROOP.Managers
             _dataDictionary.Clear();
             _rowDictionary.Clear();
 
-            List<string> newInstructions = new List<string>()
+            List<string> newInstructions = new List<string>
             {
-                "(1)", "(2)", "(3)", "(4)", "(5)",
+                "(1)", "(2)", "(3)", "(4)", "(5)"
             };
             _richTextBoxTasInstructions.Text = String.Join("\r\n", newInstructions);
         }
@@ -239,7 +239,7 @@ namespace STROOP.Managers
         public void ShowTaserVariables()
         {
             _variablePanel.ShowOnlyVariableGroups(
-                new List<VariableGroup>() { VariableGroup.TAS, VariableGroup.Custom });
+                new List<VariableGroup> { VariableGroup.TAS, VariableGroup.Custom });
         }
 
         public void SetScheduler(string text, bool useFloats)
@@ -317,7 +317,7 @@ namespace STROOP.Managers
                         invertBool: null,
                         isYaw: null,
                         coordinate: null,
-                        groupList: new List<VariableGroup>() { VariableGroup.Scheduler });
+                        groupList: new List<VariableGroup> { VariableGroup.Scheduler });
                 WatchVariableControl control = precursor.CreateWatchVariableControl();
                 AddVariable(control);
             }
@@ -326,7 +326,7 @@ namespace STROOP.Managers
         private void SetTtcReentrySchedule()
         {
             Dictionary<uint, (double, double, double, double, List<double>)> schedule =
-                new Dictionary<uint, (double, double, double, double, List<double>)>()
+                new Dictionary<uint, (double, double, double, double, List<double>)>(
                 {
                     [43816] = (-1378.91674804688f, -2434f, -1423.35168457031f, 39648, new List<double>()),
                     [43817] = (-1305.64807128906f, -2414f, -1353.34362792969f, 39648, new List<double>()),
@@ -336,7 +336,7 @@ namespace STROOP.Managers
                     [43821] = (-1219.87109375f, -2371.6005859375f, -1238.93115234375f, 39648, new List<double>()),
                     [43822] = (-1190.4560546875f, -2369.2001953125f, -1201f, 39648, new List<double>()),
                     [43823] = (-1190.4560546875f, -2370f, -1201f, 39648, new List<double>()),
-                    [43824] = (-455.207397460938f, -2374f, -457.235229492188f, 39648, new List<double>()),
+                    [43824] = (-455.207397460938f, -2374f, -457.235229492188f, 39648, new List<double>())
                 };
             SetScheduler(schedule);
         }
@@ -409,13 +409,13 @@ namespace STROOP.Managers
                 currentRow.Cells[TABLE_INDEX_X_INPUT].Value = xInput;
                 currentRow.Cells[TABLE_INDEX_Y_INPUT].Value = -1 * yInput;
 
-                List<string> newInstructions = new List<string>()
+                List<string> newInstructions = new List<string>
                 {
                     "(1) Set input to (" + xInput + "," + (-1 * yInput) + ")",
                     "(2) Frame advance",
                     "(3) Savestate",
                     "(4) Frame advance",
-                    "(5) Revert",
+                    "(5) Revert"
                 };
                 _richTextBoxTasInstructions.Text = String.Join("\r\n", newInstructions);
             }

--- a/STROOP/Managers/TestingManager.cs
+++ b/STROOP/Managers/TestingManager.cs
@@ -432,13 +432,13 @@ namespace STROOP.Managers
             switch (_scuttlebugMission)
             {
                 case ScuttlebugMission.BBHBalconyEye:
-                    return new List<uint>() { 0x803441C8, 0x80344428, 0x80344B48 };
+                    return new List<uint> { 0x803441C8, 0x80344428, 0x80344B48 };
                 case ScuttlebugMission.BBHMerryGoRound:
-                    return new List<uint>() { 0x803441C8 };
+                    return new List<uint> { 0x803441C8 };
                 case ScuttlebugMission.HMCAmazing:
-                    return new List<uint>() { 0x803408C8 };
+                    return new List<uint> { 0x803408C8 };
                 case ScuttlebugMission.HMCRedCoins:
-                    return new List<uint>() { 0x803422E8 };
+                    return new List<uint> { 0x803422E8 };
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -544,20 +544,20 @@ namespace STROOP.Managers
 
             public static VarState GetCurrent()
             {
-                return new VarStateMario()
+                return new VarStateMario
                 {
                     X = Config.Stream.GetSingle(MarioConfig.StructAddress + MarioConfig.XOffset),
                     Y = Config.Stream.GetSingle(MarioConfig.StructAddress + MarioConfig.YOffset),
                     Z = Config.Stream.GetSingle(MarioConfig.StructAddress + MarioConfig.ZOffset),
                     Angle = Config.Stream.GetUInt16(MarioConfig.StructAddress + MarioConfig.FacingYawOffset),
                     Vspd = Config.Stream.GetSingle(MarioConfig.StructAddress + MarioConfig.YSpeedOffset),
-                    Hspd = Config.Stream.GetSingle(MarioConfig.StructAddress + MarioConfig.HSpeedOffset),
+                    Hspd = Config.Stream.GetSingle(MarioConfig.StructAddress + MarioConfig.HSpeedOffset)
                 };
             }
 
             public static List<string> VarNames()
             {
-                return new List<string>()
+                return new List<string>
                 {
                     "X", "Y", "Z", "Angle", "Vspd", "Hspd"
                 };
@@ -565,7 +565,7 @@ namespace STROOP.Managers
 
             public override List<Object> VarValues()
             {
-                return new List<Object>()
+                return new List<Object>
                 {
                     X, Y, Z, Angle, Vspd, Hspd
                 };
@@ -600,15 +600,15 @@ namespace STROOP.Managers
 
             public static VarStatePenguin GetCurrent()
             {
-                return new VarStatePenguin()
+                return new VarStatePenguin
                 {
-                    Progress = TableConfig.RacingPenguinWaypoints.GetProgress(RomVersionConfig.Switch(0x80348448, 0x803451F8)),
+                    Progress = TableConfig.RacingPenguinWaypoints.GetProgress(RomVersionConfig.Switch(0x80348448, 0x803451F8))
                 };
             }
 
             public static List<string> VarNames()
             {
-                return new List<string>()
+                return new List<string>
                 {
                     "Progress"
                 };
@@ -616,7 +616,7 @@ namespace STROOP.Managers
 
             public override List<Object> VarValues()
             {
-                return new List<Object>()
+                return new List<Object>
                 {
                     Progress
                 };
@@ -918,7 +918,7 @@ namespace STROOP.Managers
         {
             string clipboardText = Clipboard.GetText();
             List<string> parsedStrings = ParsingUtilities.ParseStringList(clipboardText);
-            List<TextBox> textboxes = new List<TextBox>() { _betterTextboxGotoX, _betterTextboxGotoY, _betterTextboxGotoZ };
+            List<TextBox> textboxes = new List<TextBox> { _betterTextboxGotoX, _betterTextboxGotoY, _betterTextboxGotoZ };
             for (int i = 0; i < parsedStrings.Count && i < textboxes.Count; i++)
             {
                 textboxes[i].Text = parsedStrings[i];
@@ -928,7 +928,7 @@ namespace STROOP.Managers
 
         private void StateTransferInstructions()
         {
-            List<string> instructionList = new List<string>()
+            List<string> instructionList = new List<string>
             {
                 "This is a tool for having one m64 file start with the same state",
                 "(i.e. RNG, global timer, HOLP, etc) as another m64 file.",
@@ -942,7 +942,7 @@ namespace STROOP.Managers
                 "(6) Make sure you're selecting the correct mission.",
                 "(7) Pause the emulator.",
                 "(8) Press the Apply button in the State Transfer box in STROOP.",
-                "(9) Start a new m64 from snapshot.",
+                "(9) Start a new m64 from snapshot."
             };
             string instructions = String.Join("\r\n", instructionList);
             InfoForm.ShowValue(instructions, "State Transfer", "Instructions");
@@ -1051,7 +1051,7 @@ namespace STROOP.Managers
 
         private static int _rollingRocksScheduleIndexOffset = -8582;
         private static int _rollingRocksScheduleIndex = 47;
-        private static List<(int, double?, double?, double?, double?, string)> _rollingRocksScheduleList = new List<(int, double?, double?, double?, double?, string)>() {
+        private static List<(int, double?, double?, double?, double?, string)> _rollingRocksScheduleList = new List<(int, double?, double?, double?, double?, string)> {
             (6431,-3075.048,-4929.741,-1614.7,null,"T0 up to T1"),
             (6508,-3444.3,-5082.954,-1614.7,null,"T1 left to T2"),
             (6646,-3444.3,-4874.296,-2182.7,null,"up on T2"),
@@ -1136,7 +1136,7 @@ namespace STROOP.Managers
             (10554,-5288.326,2840,-6887.377,null,"DR observed"),
             (10566,-5112.072,2888,-6730.258,null,"star collect"),
             (10571,-5112.072,2810,-6730.258,null,"star land"),
-            (10682,-5112.072,2810,-6730.258,null,"black frame"),
+            (10682,-5112.072,2810,-6730.258,null,"black frame")
         };
 
         private static List<(int, double)> _plushRacingPenguinProgress = new List<(int, double)> {

--- a/STROOP/Managers/TriangleManager.cs
+++ b/STROOP/Managers/TriangleManager.cs
@@ -63,19 +63,19 @@ namespace STROOP.Managers
         }
 
         private static readonly List<VariableGroup> ALL_VAR_GROUPS =
-            new List<VariableGroup>()
+            new List<VariableGroup>
             {
                 VariableGroup.Basic,
                 VariableGroup.Intermediate,
-                VariableGroup.Advanced,
+                VariableGroup.Advanced
             };
 
         private static readonly List<VariableGroup> VISIBLE_VAR_GROUPS =
-            new List<VariableGroup>()
+            new List<VariableGroup>
             {
                 VariableGroup.Basic,
                 VariableGroup.Intermediate,
-                VariableGroup.Advanced,
+                VariableGroup.Advanced
             };
 
         public TriangleManager(Control tabControl, string varFilePath, WatchVariableFlowLayoutPanel watchVariablePanel)
@@ -104,10 +104,10 @@ namespace STROOP.Managers
             Label labelTriangleSelection = splitContainerTriangles.Panel1.Controls["labelTriangleSelection"] as Label;
             ControlUtilities.AddContextMenuStripFunctions(
                 labelTriangleSelection,
-                new List<string>() { "Update Norms" },
-                new List<Action>()
+                new List<string> { "Update Norms" },
+                new List<Action>
                 {
-                    () => UpdateNorms(),
+                    () => UpdateNorms()
                 });
 
             (splitContainerTriangles.Panel1.Controls["buttonGotoV1"] as Button).Click
@@ -126,21 +126,21 @@ namespace STROOP.Managers
             buttonNeutralizeTriangle.Click += (sender, e) => ButtonUtilities.NeutralizeTriangle(_triangleAddress);
             ControlUtilities.AddContextMenuStripFunctions(
                 buttonNeutralizeTriangle,
-                new List<string>() { "Neutralize", "Neutralize with 0", "Neutralize with 0x15" },
-                new List<Action>() {
+                new List<string> { "Neutralize", "Neutralize with 0", "Neutralize with 0x15" },
+                new List<Action> {
                     () => ButtonUtilities.NeutralizeTriangle(_triangleAddress),
                     () => ButtonUtilities.NeutralizeTriangle(_triangleAddress, false),
-                    () => ButtonUtilities.NeutralizeTriangle(_triangleAddress, true),
+                    () => ButtonUtilities.NeutralizeTriangle(_triangleAddress, true)
                 });
 
             Button buttonAnnihilateTriangle = splitContainerTriangles.Panel1.Controls["buttonAnnihilateTriangle"] as Button;
             buttonAnnihilateTriangle.Click += (sender, e) => ButtonUtilities.AnnihilateTriangle(_triangleAddress);
             ControlUtilities.AddContextMenuStripFunctions(
                 buttonAnnihilateTriangle,
-                new List<string>() { "Annihilate All Tri But Death Barriers" },
-                new List<Action>()
+                new List<string> { "Annihilate All Tri But Death Barriers" },
+                new List<Action>
                 {
-                    () => TriangleUtilities.AnnihilateAllTrianglesButDeathBarriers(),
+                    () => TriangleUtilities.AnnihilateAllTrianglesButDeathBarriers()
                 });
 
             var trianglePosGroupBox = splitContainerTriangles.Panel1.Controls["groupBoxTrianglePos"] as GroupBox;
@@ -207,11 +207,11 @@ namespace STROOP.Managers
             buttonTriangleShowObjTris.Click += (sender, e) => TriangleUtilities.ShowTriangles(TriangleUtilities.GetObjectTriangles());
             ControlUtilities.AddContextMenuStripFunctions(
                 buttonTriangleShowObjTris,
-                new List<string>() { "Show All Object Tris", "Show Selected Object Tris" },
-                new List<Action>()
+                new List<string> { "Show All Object Tris", "Show Selected Object Tris" },
+                new List<Action>
                 {
                     () => TriangleUtilities.ShowTriangles(TriangleUtilities.GetObjectTriangles()),
-                    () => TriangleUtilities.ShowTriangles(TriangleUtilities.GetSelectedObjectTriangles()),
+                    () => TriangleUtilities.ShowTriangles(TriangleUtilities.GetSelectedObjectTriangles())
                 });
 
             (splitContainerTriangles.Panel1.Controls["buttonTriangleShowAllTris"] as Button).Click
@@ -222,7 +222,7 @@ namespace STROOP.Managers
 
             ControlUtilities.AddContextMenuStripFunctions(
                 buttonTriangleNeutralizeAllTriangles,
-                new List<string>() {
+                new List<string> {
                     "Neutralize All Triangles",
                     "Neutralize Wall Triangles",
                     "Neutralize Floor Triangles",
@@ -232,7 +232,7 @@ namespace STROOP.Managers
                     "Neutralize Sleeping",
                     "Neutralize Loading Zones"
                 },
-                new List<Action>() {
+                new List<Action> {
                     () => TriangleUtilities.NeutralizeTriangles(),
                     () => TriangleUtilities.NeutralizeTriangles(TriangleClassification.Wall),
                     () => TriangleUtilities.NeutralizeTriangles(TriangleClassification.Floor),
@@ -245,7 +245,7 @@ namespace STROOP.Managers
                         TriangleUtilities.NeutralizeTriangles(0x1C);
                         TriangleUtilities.NeutralizeTriangles(0x1D);
                         TriangleUtilities.NeutralizeTriangles(0x1E);
-                    },
+                    }
                 });
 
             var buttonTriangleDisableAllCamCollision = splitContainerTriangles.Panel1.Controls["buttonTriangleDisableAllCamCollision"] as Button;
@@ -253,19 +253,19 @@ namespace STROOP.Managers
 
             ControlUtilities.AddContextMenuStripFunctions(
                 buttonTriangleDisableAllCamCollision,
-                new List<string>()
+                new List<string>
                 {
                     "Disable Cam Collision for All Triangles",
                     "Disable Cam Collision for Wall Triangles",
                     "Disable Cam Collision for Floor Triangles",
-                    "Disable Cam Collision for Ceiling Triangles",
+                    "Disable Cam Collision for Ceiling Triangles"
                 },
-                new List<Action>()
+                new List<Action>
                 {
                     () => TriangleUtilities.DisableCamCollision(),
                     () => TriangleUtilities.DisableCamCollision(TriangleClassification.Wall),
                     () => TriangleUtilities.DisableCamCollision(TriangleClassification.Floor),
-                    () => TriangleUtilities.DisableCamCollision(TriangleClassification.Ceiling),
+                    () => TriangleUtilities.DisableCamCollision(TriangleClassification.Ceiling)
                 });
         }
 

--- a/STROOP/Managers/VarHackManager.cs
+++ b/STROOP/Managers/VarHackManager.cs
@@ -37,7 +37,7 @@ namespace STROOP.Managers
 
             ControlUtilities.AddContextMenuStripFunctions(
                 buttonVarHackAddNewVariable,
-                new List<string>()
+                new List<string>
                 {
                     "RNG Index",
                     "Floor YNorm",
@@ -46,9 +46,9 @@ namespace STROOP.Managers
                     "Mario Action",
                     "Mario Animation",
                     "DYaw Intended - Facing",
-                    "DYaw Intended - Facing (HAU)",
+                    "DYaw Intended - Facing (HAU)"
                 },
-                new List<Action>()
+                new List<Action>
                 {
                     () => AddVariable("RngIndex"),
                     () => AddVariable("FloorYNorm"),
@@ -57,7 +57,7 @@ namespace STROOP.Managers
                     () => AddVariable("MarioAction"),
                     () => AddVariable("MarioAnimation"),
                     () => AddVariable("DYawIntendFacing"),
-                    () => AddVariable("DYawIntendFacingHau"),
+                    () => AddVariable("DYawIntendFacingHau")
                 });
 
             Button buttonVarHackOpenVars =
@@ -108,11 +108,11 @@ namespace STROOP.Managers
 
             ControlUtilities.AddContextMenuStripFunctions(
                 _buttonEnableDisableRomHack,
-                new List<string>() { "1f Delay Hack (Standard)", "0f Delay Hack (Experimental)" },
-                new List<Action>()
+                new List<string> { "1f Delay Hack (Standard)", "0f Delay Hack (Experimental)" },
+                new List<Action>
                 {
                     () => VarHackConfig.ShowVarRomHack.LoadPayload(),
-                    () => VarHackConfig.ShowVarRomHack2.LoadPayload(),
+                    () => VarHackConfig.ShowVarRomHack2.LoadPayload()
                 });
 
             // Middle buttons

--- a/STROOP/Map/MapBackgroundObject.cs
+++ b/STROOP/Map/MapBackgroundObject.cs
@@ -27,7 +27,7 @@ namespace STROOP.Map
             float yCenter = Config.MapGui.GLControlMap2D.Height / 2;
             float length = Math.Max(Config.MapGui.GLControlMap2D.Width, Config.MapGui.GLControlMap2D.Height);
             (PointF loc, SizeF size) dimension = (new PointF(xCenter, yCenter), new SizeF(length, length));
-            return new List<(PointF loc, SizeF size)>() { dimension };
+            return new List<(PointF loc, SizeF size)> { dimension };
         }
 
         public override MapDrawType GetDrawType()
@@ -56,7 +56,7 @@ namespace STROOP.Map
                 new Map3DVertex(new Vector3(leftBound, upperBound, 0), Color4, new Vector2(0, 0)),
                 new Map3DVertex(new Vector3(rightBound, upperBound, 0), Color4, new Vector2(1, 0)),
                 new Map3DVertex(new Vector3(leftBound, upperBound, 0), Color4, new Vector2(0, 0)),
-                new Map3DVertex(new Vector3(rightBound, lowerBound, 0), Color4, new Vector2(1, 1)),
+                new Map3DVertex(new Vector3(rightBound, lowerBound, 0), Color4, new Vector2(1, 1))
             };
         }
 

--- a/STROOP/Map/MapCurrentCellObject.cs
+++ b/STROOP/Map/MapCurrentCellObject.cs
@@ -31,14 +31,14 @@ namespace STROOP.Map
             int zMin = (cellZ - 8) * 1024;
             int zMax = zMin + 1024;
             List<(float x, float y, float z)> quad =
-                new List<(float x, float y, float z)>()
+                new List<(float x, float y, float z)>
                 {
                     (xMin, marioY, zMin),
                     (xMin, marioY, zMax),
                     (xMax, marioY, zMax),
-                    (xMax, marioY, zMin),
+                    (xMax, marioY, zMin)
                 };
-            return new List<List<(float x, float y, float z)>>() { quad };
+            return new List<List<(float x, float y, float z)>> { quad };
         }
 
         public override string GetName()

--- a/STROOP/Map/MapCurrentUnitObject.cs
+++ b/STROOP/Map/MapCurrentUnitObject.cs
@@ -37,14 +37,14 @@ namespace STROOP.Map
             int zMax = zMin + (posAngleZ >= 0 ? 1 : -1);
 
             List<(float x, float y, float z)> quad =
-                new List<(float x, float y, float z)>()
+                new List<(float x, float y, float z)>
                 {
                     (xMin, marioY, zMin),
                     (xMin, marioY, zMax),
                     (xMax, marioY, zMax),
-                    (xMax, marioY, zMin),
+                    (xMax, marioY, zMin)
                 };
-            return new List<List<(float x, float y, float z)>>() { quad };
+            return new List<List<(float x, float y, float z)>> { quad };
         }
 
         public override string GetName()

--- a/STROOP/Map/MapCustomBackgroundObject.cs
+++ b/STROOP/Map/MapCustomBackgroundObject.cs
@@ -39,7 +39,7 @@ namespace STROOP.Map
             if (_contextMenuStrip == null)
             {
                 List<BackgroundImage> backgroundImages = Config.MapAssociations.GetAllBackgroundImages();
-                List<object> backgroundImageChoices = new List<object>() { "Recommended" };
+                List<object> backgroundImageChoices = new List<object> { "Recommended" };
                 backgroundImages.ForEach(backgroundImage => backgroundImageChoices.Add(backgroundImage));
 
                 ToolStripMenuItem itemSelectMap = new ToolStripMenuItem("Select Background");

--- a/STROOP/Map/MapCustomMapObject.cs
+++ b/STROOP/Map/MapCustomMapObject.cs
@@ -39,7 +39,7 @@ namespace STROOP.Map
             if (_contextMenuStrip == null)
             {
                 List<MapLayout> mapLayouts = Config.MapAssociations.GetAllMaps();
-                List<object> mapLayoutChoices = new List<object>() { "Recommended" };
+                List<object> mapLayoutChoices = new List<object> { "Recommended" };
                 mapLayouts.ForEach(mapLayout => mapLayoutChoices.Add(mapLayout));
 
                 ToolStripMenuItem itemSelectMap = new ToolStripMenuItem("Select Map");

--- a/STROOP/Map/MapCylinderObject.cs
+++ b/STROOP/Map/MapCylinderObject.cs
@@ -46,15 +46,15 @@ namespace STROOP.Map
                     vertex => new Map3DVertex(new Vector3(
                         vertex.x, vertex.y, vertex.z), color)).ToArray();
             }
-            List<Map3DVertex[]> vertexArrayForBases = new List<Map3DVertex[]>()
+            List<Map3DVertex[]> vertexArrayForBases = new List<Map3DVertex[]>
             {
                 GetBaseVertices(maxY, Color4),
-                GetBaseVertices(minY, Color4),
+                GetBaseVertices(minY, Color4)
             };
-            List<Map3DVertex[]> vertexArrayForEdges = new List<Map3DVertex[]>()
+            List<Map3DVertex[]> vertexArrayForEdges = new List<Map3DVertex[]>
             {
                 GetBaseVertices(maxY, OutlineColor),
-                GetBaseVertices(minY, OutlineColor),
+                GetBaseVertices(minY, OutlineColor)
             };
 
             List<(float x, float z)> points2D = Enumerable.Range(0, NUM_POINTS_2D).ToList()
@@ -70,7 +70,7 @@ namespace STROOP.Map
                     new Map3DVertex(new Vector3(x1, maxY, z1), Color4),
                     new Map3DVertex(new Vector3(x2, maxY, z2), Color4),
                     new Map3DVertex(new Vector3(x2, minY, z2), Color4),
-                    new Map3DVertex(new Vector3(x1, minY, z1), Color4),
+                    new Map3DVertex(new Vector3(x1, minY, z1), Color4)
                 });
             }
 

--- a/STROOP/Map/MapGraphics.cs
+++ b/STROOP/Map/MapGraphics.cs
@@ -128,7 +128,7 @@ namespace STROOP.Map
                 MapViewScale = MapScale.Custom;
 
             if (MapViewScale == MapScale.CourseDefault) MapViewScaleWasCourseDefault = true;
-            if (MapViewScale == MapScale.MaxCourseSize) MapViewScaleWasCourseDefault = false;
+            else if (MapViewScale == MapScale.MaxCourseSize) MapViewScaleWasCourseDefault = false;
 
             switch (MapViewScale)
             {
@@ -136,12 +136,12 @@ namespace STROOP.Map
                 case MapScale.MaxCourseSize:
                     RectangleF rectangle = MapViewScale == MapScale.CourseDefault ?
                         MapUtilities.GetMapLayout().Coordinates : MAX_COURSE_SIZE;
-                    List<(float, float)> coordinates = new List<(float, float)>()
+                    List<(float, float)> coordinates = new List<(float, float)>
                     {
                         (rectangle.Left, rectangle.Top),
                         (rectangle.Right, rectangle.Top),
                         (rectangle.Left, rectangle.Bottom),
-                        (rectangle.Right, rectangle.Bottom),
+                        (rectangle.Right, rectangle.Bottom)
                     };
                     List<(float, float)> rotatedCoordinates = coordinates.ConvertAll(coord =>
                     {

--- a/STROOP/Map/MapHitboxHackTriangleObject.cs
+++ b/STROOP/Map/MapHitboxHackTriangleObject.cs
@@ -38,7 +38,7 @@ namespace STROOP.Map
         public override void DrawOn3DControl()
         {
             List<List<(float x, float y, float z, Color color)>> triData = GetTriangles()
-                .ConvertAll(tri => new List<(float x, float y, float z, Color color)>(
+                .ConvertAll(tri => new List<(float x, float y, float z, Color color)>
                 {
                     (tri.X1, tri.Y1, tri.Z1, ColorUtilities.AddAlpha(GetColorForTri(tri), OpacityByte)),
                     (tri.X2, tri.Y2, tri.Z2, ColorUtilities.AddAlpha(GetColorForTri(tri), OpacityByte)),

--- a/STROOP/Map/MapHitboxHackTriangleObject.cs
+++ b/STROOP/Map/MapHitboxHackTriangleObject.cs
@@ -23,7 +23,6 @@ namespace STROOP.Map
         private readonly List<uint> _objTriAddressList;
 
         public MapHitboxHackTriangleObject()
-            : base()
         {
             _levelTriAddressList = TriangleUtilities.GetLevelTriangles().ConvertAll(tri => tri.Address);
             _objTriAddressList = TriangleUtilities.GetObjectTriangles().ConvertAll(tri => tri.Address);
@@ -39,11 +38,11 @@ namespace STROOP.Map
         public override void DrawOn3DControl()
         {
             List<List<(float x, float y, float z, Color color)>> triData = GetTriangles()
-                .ConvertAll(tri => new List<(float x, float y, float z, Color color)>()
+                .ConvertAll(tri => new List<(float x, float y, float z, Color color)>(
                 {
                     (tri.X1, tri.Y1, tri.Z1, ColorUtilities.AddAlpha(GetColorForTri(tri), OpacityByte)),
                     (tri.X2, tri.Y2, tri.Z2, ColorUtilities.AddAlpha(GetColorForTri(tri), OpacityByte)),
-                    (tri.X3, tri.Y3, tri.Z3, ColorUtilities.AddAlpha(GetColorForTri(tri), OpacityByte)),
+                    (tri.X3, tri.Y3, tri.Z3, ColorUtilities.AddAlpha(GetColorForTri(tri), OpacityByte))
                 });
             Map3DVertex[] vertexArray = triData.SelectMany(vertexList => vertexList).ToList()
                 .ConvertAll(vertex => new Map3DVertex(new Vector3(

--- a/STROOP/Map/MapHorizontalTriangleObject.cs
+++ b/STROOP/Map/MapHorizontalTriangleObject.cs
@@ -156,12 +156,12 @@ namespace STROOP.Map
 
             List<List<(float x, float y, float z)>> GetSideSurfaces(int index1, int index2) =>
                 topSurfaces.ConvertAll(topSurface =>
-                    new List<(float x, float y, float z)>()
+                    new List<(float x, float y, float z)>
                     {
                         topSurface[index1],
                         topSurface[index2],
                         OffsetVertex(topSurface[index2], 0, -1 * Size, 0),
-                        OffsetVertex(topSurface[index1], 0, -1 * Size, 0),
+                        OffsetVertex(topSurface[index1], 0, -1 * Size, 0)
                     });
             List<List<(float x, float y, float z)>> side1Surfaces = GetSideSurfaces(0, 1);
             List<List<(float x, float y, float z)>> side2Surfaces = GetSideSurfaces(1, 2);

--- a/STROOP/Map/MapIconPointObject.cs
+++ b/STROOP/Map/MapIconPointObject.cs
@@ -61,7 +61,7 @@ namespace STROOP.Map
                 new Map3DVertex(new Vector3(-1, 1, 0), Color4, new Vector2(0, 0)),
                 new Map3DVertex(new Vector3(1, 1, 0), Color4, new Vector2(1, 0)),
                 new Map3DVertex(new Vector3(-1, 1, 0), Color4,  new Vector2(0, 0)),
-                new Map3DVertex(new Vector3(1, -1, 0), Color4, new Vector2(1, 1)),
+                new Map3DVertex(new Vector3(1, -1, 0), Color4, new Vector2(1, 1))
             };
         }
 

--- a/STROOP/Map/MapMapObject.cs
+++ b/STROOP/Map/MapMapObject.cs
@@ -34,7 +34,7 @@ namespace STROOP.Map
             float rectangleCenterZ = rectangle.Y + rectangle.Height / 2;
             List<(float x, float z)> rectangleCenters = Config.MapGraphics.MapViewEnablePuView ?
                 MapUtilities.GetPuCoordinates(rectangleCenterX, rectangleCenterZ) :
-                new List<(float x, float z)>() { (rectangleCenterX, rectangleCenterZ) };
+                new List<(float x, float z)> { (rectangleCenterX, rectangleCenterZ) };
             List<(float x, float z)> controlCenters = rectangleCenters.ConvertAll(
                 rectangleCenter => MapUtilities.ConvertCoordsForControl(rectangleCenter.x, rectangleCenter.z));
             float sizeX = rectangle.Width * Config.MapGraphics.MapViewScaleValue;

--- a/STROOP/Map/MapNextPositionsObject.cs
+++ b/STROOP/Map/MapNextPositionsObject.cs
@@ -110,7 +110,7 @@ namespace STROOP.Map
                 new Map3DVertex(new Vector3(-1, 1, 0), Color4, new Vector2(0, 0)),
                 new Map3DVertex(new Vector3(1, 1, 0), Color4, new Vector2(1, 0)),
                 new Map3DVertex(new Vector3(-1, 1, 0), Color4,  new Vector2(0, 0)),
-                new Map3DVertex(new Vector3(1, -1, 0), Color4, new Vector2(1, 1)),
+                new Map3DVertex(new Vector3(1, -1, 0), Color4, new Vector2(1, 1))
             };
         }
 

--- a/STROOP/Map/MapPathObject.cs
+++ b/STROOP/Map/MapPathObject.cs
@@ -112,7 +112,7 @@ namespace STROOP.Map
                 vertexArrayList.Add(new Map3DVertex[]
                 {
                     new Map3DVertex(new Vector3(x1, y1, z1), color),
-                    new Map3DVertex(new Vector3(x2, y2, z2), color),
+                    new Map3DVertex(new Vector3(x2, y2, z2), color)
                 });
             }
 

--- a/STROOP/Map/MapSphereObject.cs
+++ b/STROOP/Map/MapSphereObject.cs
@@ -58,12 +58,12 @@ namespace STROOP.Map
                 {
                     float theta1 = thetaValues[t];
                     float theta2 = thetaValues[(t + 1) % thetaValues.Count];
-                    List<(float x, float y, float z)> pointsList = new List<(float x, float y, float z)>()
+                    List<(float x, float y, float z)> pointsList = new List<(float x, float y, float z)>
                     {
                         GetSpherePoint(radius3D, theta1, phi1, centerX, centerY, centerZ),
                         GetSpherePoint(radius3D, theta1, phi2, centerX, centerY, centerZ),
                         GetSpherePoint(radius3D, theta2, phi2, centerX, centerY, centerZ),
-                        GetSpherePoint(radius3D, theta2, phi1, centerX, centerY, centerZ),
+                        GetSpherePoint(radius3D, theta2, phi1, centerX, centerY, centerZ)
                     };
                     Map3DVertex[] pointsArray = pointsList.ConvertAll(
                         vertex => new Map3DVertex(new Vector3(

--- a/STROOP/Map/MapTracker.cs
+++ b/STROOP/Map/MapTracker.cs
@@ -33,7 +33,7 @@ namespace STROOP.Map
         private string _customName;
 
         public MapTracker(MapObject mapObj, List<MapSemaphore> semaphoreList = null)
-            : this(new List<MapObject>() { mapObj }, semaphoreList)
+            : this(new List<MapObject> { mapObj }, semaphoreList)
         {
         }
 
@@ -58,7 +58,7 @@ namespace STROOP.Map
             _customName = null;
             textBoxName.AddEnterAction(() => _customName = textBoxName.Text);
             textBoxName.AddLostFocusAction(() => _customName = textBoxName.Text);
-            textBoxName.AddDoubleClickAction(() => textBoxName.SelectAll());
+            textBoxName.AddDoubleClickAction(textBoxName.SelectAll);
             textBoxName.ContextMenuStrip = new ContextMenuStrip();
             ToolStripMenuItem itemResetCustomName = new ToolStripMenuItem("Reset Custom Name");
             itemResetCustomName.Click += (sender, e) => _customName = null;
@@ -86,12 +86,12 @@ namespace STROOP.Map
             SetColor(null);
             SetOutlineColor(null);
 
-            textBoxSize.AddEnterAction(() => textBoxSize_EnterAction());
-            trackBarSize.AddManualChangeAction(() => trackBarSize_ValueChanged());
-            textBoxOpacity.AddEnterAction(() => textBoxOpacity_EnterAction());
-            trackBarOpacity.AddManualChangeAction(() => trackBarOpacity_ValueChanged());
-            textBoxOutlineWidth.AddEnterAction(() => textBoxOutlineWidth_EnterAction());
-            trackBarOutlineWidth.AddManualChangeAction(() => trackBarOutlineWidth_ValueChanged());
+            textBoxSize.AddEnterAction(textBoxSize_EnterAction);
+            trackBarSize.AddManualChangeAction(trackBarSize_ValueChanged);
+            textBoxOpacity.AddEnterAction(textBoxOpacity_EnterAction);
+            trackBarOpacity.AddManualChangeAction(trackBarOpacity_ValueChanged);
+            textBoxOutlineWidth.AddEnterAction(textBoxOutlineWidth_EnterAction);
+            trackBarOutlineWidth.AddManualChangeAction(trackBarOutlineWidth_ValueChanged);
             colorSelector.AddColorChangeAction((Color color) => SetColor(color));
             colorSelectorOutline.AddColorChangeAction((Color color) => SetOutlineColor(color));
 
@@ -106,7 +106,7 @@ namespace STROOP.Map
 
         private void InitializeTrackBarContextMenuStrips()
         {
-            List<int> maxValues = new List<int>() { 10, 100, 1000, 10000, 100000 };
+            List<int> maxValues = new List<int> { 10, 100, 1000, 10000, 100000 };
             Action<TrackBar, Action> initializeContextMenuStrip = (TrackBar trackBar, Action resetAction) =>
             {
                 trackBar.ContextMenuStrip = new ContextMenuStrip();
@@ -124,7 +124,7 @@ namespace STROOP.Map
                     };
                     if (trackBar.Maximum == maxValue) item.Checked = true;
                     trackBar.ContextMenuStrip.Items.Add(item);
-                };
+                }
             };
             initializeContextMenuStrip(trackBarSize, () => SetSize(null));
             initializeContextMenuStrip(trackBarOutlineWidth, () => SetOutlineWidth(null));

--- a/STROOP/Map/MapUtilities.cs
+++ b/STROOP/Map/MapUtilities.cs
@@ -17,7 +17,7 @@ namespace STROOP.Map
     public static class MapUtilities
     {
         public static int WhiteTexture { get; }
-        private static readonly byte[] _whiteTexData = new byte[] { 0xFF };
+        private static readonly byte[] _whiteTexData = { 0xFF };
 
         static MapUtilities()
         {
@@ -174,7 +174,7 @@ namespace STROOP.Map
 
         public static List<TriangleDataModel> GetTriangles(uint triAddresses)
         {
-            return GetTriangles(new List<uint>() { triAddresses });
+            return GetTriangles(new List<uint> { triAddresses });
         }
 
         public static List<TriangleDataModel> GetTriangles(List<uint> triAddresses)
@@ -188,12 +188,12 @@ namespace STROOP.Map
             List<List<(float x, float y, float z)>> quadList = new List<List<(float x, float y, float z)>>();
             Action<int, int, int, int> addQuad = (int xBase, int zBase, int xAdd, int zAdd) =>
             {
-                quadList.Add(new List<(float x, float y, float z)>()
+                quadList.Add(new List<(float x, float y, float z)>
                 {
                     (xBase, 0, zBase),
                     (xBase + xAdd, 0, zBase),
                     (xBase + xAdd, 0, zBase + zAdd),
-                    (xBase, 0, zBase + zAdd),
+                    (xBase, 0, zBase + zAdd)
                 });
             };
             foreach ((int x, int z) in unitPoints)

--- a/STROOP/Map/MapWallObject.cs
+++ b/STROOP/Map/MapWallObject.cs
@@ -46,12 +46,12 @@ namespace STROOP.Map
                 List<List<(float x, float z)>> quads = new List<List<(float x, float z)>>();
                 Action<float, float> addQuad = (float xAdd, float zAdd) =>
                 {
-                    quads.Add(new List<(float x, float z)>()
+                    quads.Add(new List<(float x, float z)>
                     {
                         (x1, z1),
                         (x1 + xAdd, z1 + zAdd),
                         (x2 + xAdd, z2 + zAdd),
-                        (x2, z2),
+                        (x2, z2)
                     });
                 };
                 if (xProjection)
@@ -165,12 +165,12 @@ namespace STROOP.Map
                     float xOffsetMag = xProjection ? projectionMag : 0;
                     float zOffsetMag = xProjection ? 0 : projectionMag;
                     List<(float x, float y, float z)> vertices = tri.Get3DVertices();
-                    return new List<(float x, float y, float z)>()
+                    return new List<(float x, float y, float z)>
                     {
                         OffsetVertex(vertices[index1], xOffsetMag, relativeHeight, zOffsetMag),
                         OffsetVertex(vertices[index2], xOffsetMag, relativeHeight, zOffsetMag),
                         OffsetVertex(vertices[index2], -1 * xOffsetMag, relativeHeight, -1 * zOffsetMag),
-                        OffsetVertex(vertices[index1], -1 * xOffsetMag, relativeHeight, -1 * zOffsetMag),
+                        OffsetVertex(vertices[index1], -1 * xOffsetMag, relativeHeight, -1 * zOffsetMag)
                     };
                 });
             List<List<(float x, float y, float z)>> side1Surfaces = GetSideSurfaces(0, 1);

--- a/STROOP/Models/ObjectDataModel.cs
+++ b/STROOP/Models/ObjectDataModel.cs
@@ -283,13 +283,13 @@ namespace STROOP.Models
                 Config.ObjectAssociations.AlignJPBehavior(SegmentedBehavior),
                 SegmentedBehavior); // Shindou objects are the same as U
 
-            BehaviorCriteria = new BehaviorCriteria()
+            BehaviorCriteria = new BehaviorCriteria
             {
                 BehaviorAddress = behaviorAddress,
                 GfxId = _gfxId,
                 SubType = _subType,
                 Appearance = _appearance,
-                SpawnObj = _spawnObj,
+                SpawnObj = _spawnObj
             };
 
             BehaviorAssociation = Config.ObjectAssociations.FindObjectAssociation(BehaviorCriteria);

--- a/STROOP/Models/TriangleDataModel.cs
+++ b/STROOP/Models/TriangleDataModel.cs
@@ -250,7 +250,7 @@ namespace STROOP.Models
 
         public List<(float x, float z)> Get2DVertices()
         {
-            return new List<(float, float)>()
+            return new List<(float, float)>
             {
                 (X1, Z1), (X2, Z2), (X3, Z3)
             };
@@ -258,7 +258,7 @@ namespace STROOP.Models
 
         public List<(float x, float y, float z)> Get3DVertices()
         {
-            return new List<(float, float, float)>()
+            return new List<(float, float, float)>
             {
                 (X1, Y1, Z1), (X2, Y2, Z2), (X3, Y3, Z3)
             };

--- a/STROOP/STROOP.csproj
+++ b/STROOP/STROOP.csproj
@@ -426,31 +426,31 @@
     <Compile Include="Structs\PendulumVertexTable.cs" />
     <Compile Include="Structs\TriangleInfoTable.cs" />
     <Compile Include="Structs\PointTable.cs" />
-    <Compile Include="Ttc\TtcPendulum2.cs" />
-    <Compile Include="Ttc\TtcRng2.cs" />
-    <Compile Include="Ttc\TtcSaveStateByteIterator.cs" />
-    <Compile Include="Ttc\TtcUtilities.cs" />
-    <Compile Include="Ttc\TtcSimulation.cs" />
-    <Compile Include="Ttc\TtcRng.cs" />
-    <Compile Include="Ttc\TtcMain.cs" />
-    <Compile Include="Ttc\TtcSaveState.cs" />
-    <Compile Include="Ttc\TtcWheel.cs" />
-    <Compile Include="Ttc\TtcTreadmill.cs" />
-    <Compile Include="Ttc\TtcThwomp.cs" />
-    <Compile Include="Ttc\TtcSpinningTriangle.cs" />
-    <Compile Include="Ttc\TtcSpinner.cs" />
-    <Compile Include="Ttc\TtcRotatingTriangularPrism.cs" />
-    <Compile Include="Ttc\TtcPusher.cs" />
-    <Compile Include="Ttc\TtcRotatingBlock.cs" />
-    <Compile Include="Ttc\TtcPitBlock.cs" />
-    <Compile Include="Ttc\TtcPendulum.cs" />
-    <Compile Include="Ttc\TtcHand.cs" />
-    <Compile Include="Ttc\TtcElevator.cs" />
-    <Compile Include="Ttc\TtcDust.cs" />
-    <Compile Include="Ttc\TtcCog.cs" />
-    <Compile Include="Ttc\TtcBobomb.cs" />
-    <Compile Include="Ttc\TtcAmp.cs" />
-    <Compile Include="Ttc\TtcObject.cs" />
+    <Compile Include="TTC\TtcPendulum2.cs" />
+    <Compile Include="TTC\TtcRng2.cs" />
+    <Compile Include="TTC\TtcSaveStateByteIterator.cs" />
+    <Compile Include="TTC\TtcUtilities.cs" />
+    <Compile Include="TTC\TtcSimulation.cs" />
+    <Compile Include="TTC\TTCRNG.cs" />
+    <Compile Include="TTC\TTCMain.cs" />
+    <Compile Include="TTC\TtcSaveState.cs" />
+    <Compile Include="TTC\TTCWheel.cs" />
+    <Compile Include="TTC\TTCTreadmill.cs" />
+    <Compile Include="TTC\TTCThwomp.cs" />
+    <Compile Include="TTC\TTCSpinningTriangle.cs" />
+    <Compile Include="TTC\TTCSpinner.cs" />
+    <Compile Include="TTC\TTCRotatingTriangularPrism.cs" />
+    <Compile Include="TTC\TTCPusher.cs" />
+    <Compile Include="TTC\TTCRotatingBlock.cs" />
+    <Compile Include="TTC\TTCPitBlock.cs" />
+    <Compile Include="TTC\TTCPendulum.cs" />
+    <Compile Include="TTC\TTCHand.cs" />
+    <Compile Include="TTC\TTCElevator.cs" />
+    <Compile Include="TTC\TTCDust.cs" />
+    <Compile Include="TTC\TTCCog.cs" />
+    <Compile Include="TTC\TTCBobomb.cs" />
+    <Compile Include="TTC\TTCAmp.cs" />
+    <Compile Include="TTC\TTCObject.cs" />
     <Compile Include="M64\M64CopiedFrame.cs" />
     <Compile Include="M64\M64File.cs" />
     <Compile Include="M64\M64InputCell.cs" />
@@ -1014,21 +1014,21 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>del "$(TargetDir)OpenTK.dll.config"
-del "$(TargetDir)OpenTK.GLControl.xml"
-del "$(TargetDir)OpenTK.xml"
-del "$(TargetDir)STROOP.exe.config"
-</PostBuildEvent>
-  </PropertyGroup>
-  <PropertyGroup>
-    <PreBuildEvent>xcopy /E /Y /I "$(ProjectDir)Resources" "$(TargetDir)Resources" /D</PreBuildEvent>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
+    <ItemGroup>
+      <RESOURCES Include="$(ProjectDir)Resources\**\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(RESOURCES)"
+          DestinationFiles="$(TargetDir)Resources\%(RecursiveDir)%(Filename)%(Extension)"
+          SkipUnchangedFiles="true" />
   </Target>
   <Target Name="AfterBuild">
+    <Delete Files="$(TargetDir)OpenTK.dll.config" />
+    <Delete Files="$(TargetDir)OpenTK.GLControl.xml" />
+    <Delete Files="$(TargetDir)OpenTK.xml" />
+    <Delete Files="$(TargetDir)STROOP.exe.config" />
   </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
   -->
 </Project>

--- a/STROOP/Structs/BehaviorCriteria.cs
+++ b/STROOP/Structs/BehaviorCriteria.cs
@@ -56,16 +56,16 @@ namespace STROOP.Structs
                 return null;
 
             if (GfxId.HasValue && otherCriteria.GfxId.HasValue && GfxId.Value != otherCriteria.GfxId.Value)
-                return new BehaviorCriteria() { BehaviorAddress = BehaviorAddress};
+                return new BehaviorCriteria { BehaviorAddress = BehaviorAddress};
 
             if (SubType.HasValue && otherCriteria.SubType.HasValue && SubType.Value != otherCriteria.SubType.Value)
-                return new BehaviorCriteria() { BehaviorAddress = BehaviorAddress, GfxId = GfxId};
+                return new BehaviorCriteria { BehaviorAddress = BehaviorAddress, GfxId = GfxId};
 
             if (Appearance.HasValue && otherCriteria.Appearance.HasValue && Appearance.Value != otherCriteria.Appearance.Value)
-                return new BehaviorCriteria() { BehaviorAddress = BehaviorAddress, GfxId = GfxId, SubType = SubType };
+                return new BehaviorCriteria { BehaviorAddress = BehaviorAddress, GfxId = GfxId, SubType = SubType };
 
             if (SpawnObj.HasValue && otherCriteria.SpawnObj.HasValue && SpawnObj.Value != otherCriteria.SpawnObj.Value)
-                return new BehaviorCriteria() { BehaviorAddress = BehaviorAddress, GfxId = GfxId, SubType = SubType, Appearance = Appearance };
+                return new BehaviorCriteria { BehaviorAddress = BehaviorAddress, GfxId = GfxId, SubType = SubType, Appearance = Appearance };
 
             return this;
         }

--- a/STROOP/Structs/Configurations/CameraConfig.cs
+++ b/STROOP/Structs/Configurations/CameraConfig.cs
@@ -73,12 +73,12 @@ namespace STROOP.Structs.Configurations
         {
             get
             {
-                return new List<uint>()
+                return new List<uint>
                 {
                     FovFunctionAwakeAddress,
                     FovFunctionSleepingAddress,
                     FovFunctionUseDoorAddress,
-                    FovFunctionCollectStarAddress,
+                    FovFunctionCollectStarAddress
                 };
             }
         }
@@ -87,12 +87,12 @@ namespace STROOP.Structs.Configurations
         {
             get
             {
-                return new List<uint>()
+                return new List<uint>
                 {
                     FovFunctionAwakeValue,
                     FovFunctionSleepingValue,
                     FovFunctionUseDoorValue,
-                    FovFunctionCollectStarValue,
+                    FovFunctionCollectStarValue
                 };
             }
         }

--- a/STROOP/Structs/Configurations/M64Config.cs
+++ b/STROOP/Structs/Configurations/M64Config.cs
@@ -24,7 +24,7 @@ namespace STROOP.Structs
         public static readonly int PasteWarningLimit = 10000;
 
         public static readonly int HeaderSize = 0x400;
-        public static readonly byte[] SignatureBytes = new byte[] { 0x4D, 0x36, 0x34, 0x1A };
+        public static readonly byte[] SignatureBytes = { 0x4D, 0x36, 0x34, 0x1A };
 
         public static readonly ushort CountryCodeUS = 69;
         public static readonly ushort CountryCodeJP = 74;

--- a/STROOP/Structs/Configurations/ObjectSlotsConfig.cs
+++ b/STROOP/Structs/Configurations/ObjectSlotsConfig.cs
@@ -16,7 +16,7 @@ namespace STROOP.Structs
         public static readonly int MaxSlots = 240;
 
         private static readonly Dictionary<byte, Color> ProcessingGroupsColor =
-            new Dictionary<byte, Color>()
+            new Dictionary<byte, Color>
             {
                 [0x0B] = Color.FromArgb(255, 000, 165), // pink
                 [0x09] = Color.FromArgb(255, 000, 000), // red
@@ -27,7 +27,7 @@ namespace STROOP.Structs
                 [0x02] = Color.FromArgb(000, 255, 233), // light blue
                 [0x06] = Color.FromArgb(000, 021, 255), // dark blue
                 [0x08] = Color.FromArgb(128, 000, 255), // purple
-                [0x0C] = Color.FromArgb(155, 095, 028), // brown
+                [0x0C] = Color.FromArgb(155, 095, 028)  // brown
             };
         public static readonly Color VacantSlotColor = Color.FromArgb(170, 170, 170); // grey
         public static Color GetProcessingGroupColor(byte? group)

--- a/STROOP/Structs/Configurations/SavedSettingsConfig.cs
+++ b/STROOP/Structs/Configurations/SavedSettingsConfig.cs
@@ -334,7 +334,7 @@ namespace STROOP.Structs.Configurations
                 new XElement("CloningUpdatesHolpType", _cloningUpdatesHolpType),
                 new XElement("UseInGameTrigForAngleLogic", _useInGameTrigForAngleLogic),
                 tabOrderXElement,
-                removedTabsXElement,
+                removedTabsXElement
             };
         }
 

--- a/STROOP/Structs/ObjectAssociations.cs
+++ b/STROOP/Structs/ObjectAssociations.cs
@@ -105,16 +105,16 @@ namespace STROOP.Structs
         public bool AddEmptyAssociation()
         {
             return AddAssociation(
-                new ObjectBehaviorAssociation()
+                new ObjectBehaviorAssociation
                 {
                     Name = "Uninitialized Object",
-                    Criteria = new BehaviorCriteria()
+                    Criteria = new BehaviorCriteria
                     {
-                        BehaviorAddress = 0x0000,
+                        BehaviorAddress = 0x0000
                     },
                     RotatesOnMap = false,
                     Image = EmptyImage,
-                    MapImage = EmptyImage,
+                    MapImage = EmptyImage
                 });
         }
 

--- a/STROOP/Structs/PendulumSwingTable.cs
+++ b/STROOP/Structs/PendulumSwingTable.cs
@@ -172,10 +172,10 @@ namespace STROOP.Structs
 
             public List<PendulumSwing> GetSuccessors()
             {
-                return new List<PendulumSwing>()
+                return new List<PendulumSwing>
                 {
                     new PendulumSwing((int)WatchVariableSpecialUtilities.GetPendulumAmplitude(Amplitude, 13), 13, this, PrimaryIndex, SecondaryIndex + 1),
-                    new PendulumSwing((int)WatchVariableSpecialUtilities.GetPendulumAmplitude(Amplitude, 42), 42, this, PrimaryIndex, SecondaryIndex + 1),
+                    new PendulumSwing((int)WatchVariableSpecialUtilities.GetPendulumAmplitude(Amplitude, 42), 42, this, PrimaryIndex, SecondaryIndex + 1)
                 };
             }
 

--- a/STROOP/Utilities/AreaUtilities.cs
+++ b/STROOP/Utilities/AreaUtilities.cs
@@ -75,7 +75,7 @@ namespace STROOP.Structs
 
         public static List<string> GetDescriptions()
         {
-            return new List<string>()
+            return new List<string>
             {
                 "Grassy",
                 "Normal",
@@ -83,7 +83,7 @@ namespace STROOP.Structs
                 "Sandy",
                 "Spooky",
                 "Aquatic",
-                "Slide",
+                "Slide"
             };
         }
 

--- a/STROOP/Utilities/BehaviorDecoder.cs
+++ b/STROOP/Utilities/BehaviorDecoder.cs
@@ -70,7 +70,7 @@ namespace STROOP.Utilities
             Cmd_37 = 0x37,
         };
 
-        static readonly Dictionary<BehaviorCommandType, int> BehaviorCommandLength = new Dictionary<BehaviorCommandType, int>()
+        static readonly Dictionary<BehaviorCommandType, int> BehaviorCommandLength = new Dictionary<BehaviorCommandType, int>
         {
             { BehaviorCommandType.Start, 4 },
             { BehaviorCommandType.Cmd_01, 4 },
@@ -127,10 +127,10 @@ namespace STROOP.Utilities
             { BehaviorCommandType.Cmd_34, 4 },
             { BehaviorCommandType.Cmd_35, 4 },
             { BehaviorCommandType.Cmd_36, 8 },
-            { BehaviorCommandType.Cmd_37, 8 },
+            { BehaviorCommandType.Cmd_37, 8 }
         };
 
-        static Dictionary<short, string> OffsetNames = new Dictionary<short, string>()
+        static Dictionary<short, string> OffsetNames = new Dictionary<short, string>
         {
             {0x8C, "flags"},
             {0x9C, "collision_timer"},
@@ -141,7 +141,7 @@ namespace STROOP.Utilities
             {0xB0, "y_speed"},
             {0xB4, "z_speed"},
             {0xB8, "h_speed"},
-            {0xE4, "gravity"},
+            {0xE4, "gravity"}
         };
 
         private static string GetOffsetName(short offset)

--- a/STROOP/Utilities/ButtonUtilities.cs
+++ b/STROOP/Utilities/ButtonUtilities.cs
@@ -22,7 +22,7 @@ namespace STROOP.Utilities
             float xValue, float yValue, float zValue, Change change, bool useRelative = false, bool handleScaling = true,
             (bool affectX, bool affectY, bool affectZ)? affects = null)
         {
-            if (posAngles.Count() == 0)
+            if (!posAngles.Any())
                 return false;
 
             bool success = true;
@@ -639,7 +639,7 @@ namespace STROOP.Utilities
 
         public static bool RetrieveSnow(int index)
         {
-            List<PositionAngle> posAngles = new List<PositionAngle>() { PositionAngle.Snow(index) };
+            List<PositionAngle> posAngles = new List<PositionAngle> { PositionAngle.Snow(index) };
 
             float xDestination = DataModels.Mario.X;
             float yDestination = DataModels.Mario.Y;
@@ -652,7 +652,7 @@ namespace STROOP.Utilities
 
         public static bool TranslateSnow(int index, float xOffset, float yOffset, float zOffset, bool useRelative)
         {
-            List<PositionAngle> posAngles = new List<PositionAngle>() { PositionAngle.Snow(index) };
+            List<PositionAngle> posAngles = new List<PositionAngle> { PositionAngle.Snow(index) };
             return ChangeValues(posAngles, xOffset, yOffset, zOffset, Change.ADD, useRelative);
         }
 

--- a/STROOP/Utilities/CoinTrajectoryFilter.cs
+++ b/STROOP/Utilities/CoinTrajectoryFilter.cs
@@ -42,8 +42,7 @@ namespace STROOP.Utilities
             if (NumQualifiedCoinsMinNullable.HasValue)
             {
                 int numQualifiedCoinsMin = NumQualifiedCoinsMinNullable.Value;
-                int numQualifiedCoins = coinTrajectoryList.FindAll(
-                    coinTrajectory => Qualifies(coinTrajectory)).Count;
+                int numQualifiedCoins = coinTrajectoryList.Count(Qualifies);
                 if (numQualifiedCoins < numQualifiedCoinsMin) return false;
             }
             return true;

--- a/STROOP/Utilities/ColorUtilities.cs
+++ b/STROOP/Utilities/ColorUtilities.cs
@@ -9,7 +9,7 @@ namespace STROOP.Utilities
     public static class ColorUtilities
     {
         public static readonly Dictionary<string, string> ColorToParamsDictionary =
-            new Dictionary<string, string>()
+            new Dictionary<string, string>
             {
                 ["Red"] = "#FFD7D7",
                 ["Orange"] = "#FFE2B7",
@@ -19,7 +19,7 @@ namespace STROOP.Utilities
                 ["Blue"] = "#CADDFF",
                 ["Purple"] = "#E5CCFF",
                 ["Pink"] = "#FFCCFF",
-                ["Grey"] = "#D0D0D0",
+                ["Grey"] = "#D0D0D0"
             };
 
         public static readonly List<Color> ColorList =

--- a/STROOP/Utilities/ControlUtilities.cs
+++ b/STROOP/Utilities/ControlUtilities.cs
@@ -104,7 +104,7 @@ namespace STROOP.Utilities
 
             // Implement ToolStripMenu
 
-            List<Button> buttonList = new List<Button>()
+            List<Button> buttonList = new List<Button>
             {
                 buttonSquareUp,
                 buttonSquareUpRight,
@@ -113,7 +113,7 @@ namespace STROOP.Utilities
                 buttonSquareDown,
                 buttonSquareDownLeft,
                 buttonSquareLeft,
-                buttonSquareUpLeft,
+                buttonSquareUpLeft
             };
 
             List<Point> positionList = buttonList.ConvertAll(
@@ -131,7 +131,7 @@ namespace STROOP.Utilities
             int lastDirection = 0;
 
             List<ToolStripMenuItem> itemList =
-                new List<ToolStripMenuItem>()
+                new List<ToolStripMenuItem>
                 {
                     itemUp,
                     itemUpRight,
@@ -140,7 +140,7 @@ namespace STROOP.Utilities
                     itemDown,
                     itemDownLeft,
                     itemLeft,
-                    itemUpLeft,
+                    itemUpLeft
                 };
 
             Action<int, bool> SetFacingDirection = (int direction, bool inverted) =>

--- a/STROOP/Utilities/DecompilerFunctionUtilities.cs
+++ b/STROOP/Utilities/DecompilerFunctionUtilities.cs
@@ -6,9 +6,9 @@ using System.Threading.Tasks;
 
 namespace STROOP.Utilities
 {
-    public class DecompilerFunctionUtilities
+    public static class DecompilerFunctionUtilities
     {
-        static readonly byte[] ReturnBytes = new byte[] { 0x08, 0x00, 0xE0, 0x03 };
+        static readonly byte[] ReturnBytes = { 0x08, 0x00, 0xE0, 0x03 };
         static readonly int MaximumInstructions = 1000;
 
         public static int? FindEndAddress(uint startAddress, byte[] ramState)
@@ -28,7 +28,7 @@ namespace STROOP.Utilities
                     return null;
             }
 
-            instructionCount += 2; // 
+            instructionCount += 2;
 
             return instructionCount;
         }

--- a/STROOP/Utilities/DemoCounterUtilities.cs
+++ b/STROOP/Utilities/DemoCounterUtilities.cs
@@ -138,7 +138,7 @@ namespace STROOP.Structs
 
         public static List<string> GetDescriptions()
         {
-            return new List<string>()
+            return new List<string>
             {
                 "Bowser 1",
                 "WF",
@@ -146,7 +146,7 @@ namespace STROOP.Structs
                 "BBH",
                 "JRB",
                 "HMC",
-                "PSS",
+                "PSS"
             };
         }
 

--- a/STROOP/Utilities/DialogUtilities.cs
+++ b/STROOP/Utilities/DialogUtilities.cs
@@ -76,17 +76,17 @@ namespace STROOP.Structs
 
         public static OpenFileDialog CreateOpenFileDialog(FileType fileType)
         {
-            return new OpenFileDialog()
+            return new OpenFileDialog
             {
-                Filter = GetFilterString(fileType),
+                Filter = GetFilterString(fileType)
             };
         }
 
         public static SaveFileDialog CreateSaveFileDialog(FileType fileType)
         {
-            return new SaveFileDialog()
+            return new SaveFileDialog
             {
-                Filter = GetFilterString(fileType),
+                Filter = GetFilterString(fileType)
             };
         }
 

--- a/STROOP/Utilities/EndiannessUtilities.cs
+++ b/STROOP/Utilities/EndiannessUtilities.cs
@@ -70,7 +70,7 @@ namespace STROOP.Utilities
             return (address & 0x03) != 0;
         }
 
-        static readonly byte[] _bytesToAlignment = new byte[] { 0x00, 0x03, 0x02, 0x01 };
+        static readonly byte[] _bytesToAlignment = { 0x00, 0x03, 0x02, 0x01 };
         public static int NumberOfBytesToAlignment(UIntPtr address)
         {
             return _bytesToAlignment[address.ToUInt64() & 0x03];

--- a/STROOP/Utilities/HelpfulHintUtilities.cs
+++ b/STROOP/Utilities/HelpfulHintUtilities.cs
@@ -13,7 +13,7 @@ namespace STROOP.Structs
     public static class HelpfulHintUtilities
     {
         private static readonly List<string> _helpfulHints =
-            new List<string>()
+            new List<string>
             {
                 // Right clicking
                 "Right click on object slots to access object functions from any tab, e.g. \"Goto\", \"Clone\", \"Unload\".",

--- a/STROOP/Utilities/MoreMath.cs
+++ b/STROOP/Utilities/MoreMath.cs
@@ -184,8 +184,8 @@ namespace STROOP.Utilities
             pX = PuUtilities.GetRelativeCoordinate(pX);
             pZ = PuUtilities.GetRelativeCoordinate(pZ);
 
-            double[] vX = new double[] { v1X, v2X, v3X };
-            double[] vZ = new double[] { v1Z, v2Z, v3Z };
+            double[] vX = { v1X, v2X, v3X };
+            double[] vZ = { v1Z, v2Z, v3Z };
 
             double p1X = vX[p1Index - 1];
             double p1Z = vZ[p1Index - 1];

--- a/STROOP/Utilities/MupenUtilities.cs
+++ b/STROOP/Utilities/MupenUtilities.cs
@@ -48,7 +48,7 @@ namespace STROOP.Utilities
 
         public static int GetFrameCount()
         {
-            if (!IsUsingMupen()) throw new ArgumentOutOfRangeException("Not using mupen");
+            if (!IsUsingMupen()) throw new InvalidOperationException("Not using mupen");
             byte[] buffer = new byte[4];
             Config.Stream.ReadProcessMemory(FrameCountAddress, buffer, EndiannessType.Little);
             int frameCount = BitConverter.ToInt32(buffer, 0);
@@ -57,7 +57,7 @@ namespace STROOP.Utilities
 
         public static int GetVICount()
         {
-            if (!IsUsingMupen()) throw new ArgumentOutOfRangeException("Not using mupen");
+            if (!IsUsingMupen()) throw new InvalidOperationException("Not using mupen");
             byte[] buffer = new byte[4];
             Config.Stream.ReadProcessMemory(VICountAddress, buffer, EndiannessType.Little);
             int viCount = BitConverter.ToInt32(buffer, 0);

--- a/STROOP/Utilities/N64Disassembler.cs
+++ b/STROOP/Utilities/N64Disassembler.cs
@@ -368,7 +368,7 @@ namespace STROOP.Utilities
             (i) => { return "Unk"; },
             (i) => { return "Unk"; },
             (i) => { return "Unk"; },
-            (i) => { return "Unk"; },
+            (i) => { return "Unk"; }
         };
 
         private static string disassembleCop0(Instruction i)

--- a/STROOP/Utilities/ObjectSnapshot.cs
+++ b/STROOP/Utilities/ObjectSnapshot.cs
@@ -15,15 +15,15 @@ namespace STROOP.Utilities
 
         private readonly List<uint> uintValues;
 
-        private static readonly List<uint> _primaryVariables = new List<uint>()
+        private static readonly List<uint> _primaryVariables = new List<uint>
         {
             ObjectConfig.NextLinkOffset,
             ObjectConfig.PreviousLinkOffset,
             ObjectConfig.ProcessedNextLinkOffset,
-            ObjectConfig.ProcessedPreviousLinkOffset,
+            ObjectConfig.ProcessedPreviousLinkOffset
         };
 
-        private static readonly List<uint> _secondaryVariables = new List<uint>()
+        private static readonly List<uint> _secondaryVariables = new List<uint>
         {
             ObjectConfig.NextLinkOffset,
             ObjectConfig.PreviousLinkOffset,
@@ -40,7 +40,7 @@ namespace STROOP.Utilities
             ObjectConfig.RollFacingOffsetUInt,
             ObjectConfig.YawMovingOffsetUInt,
             ObjectConfig.PitchMovingOffsetUInt,
-            ObjectConfig.RollMovingOffsetUInt,
+            ObjectConfig.RollMovingOffsetUInt
         };
 
         public ObjectSnapshot(uint address)

--- a/STROOP/Utilities/ObjectUtilities.cs
+++ b/STROOP/Utilities/ObjectUtilities.cs
@@ -48,7 +48,7 @@ namespace STROOP.Utilities
         public static List<uint> GetAllObjectAddresses()
         {
             return Enumerable.Range(0, ObjectSlotsConfig.MaxSlots).ToList()
-                .ConvertAll(index => GetObjectAddress(index));
+                .ConvertAll(GetObjectAddress);
         }
 
         public static uint? GetCollisionObject(uint objAddress, int collisionIndex)

--- a/STROOP/Utilities/ParsingUtilities.cs
+++ b/STROOP/Utilities/ParsingUtilities.cs
@@ -273,7 +273,7 @@ namespace STROOP.Utilities
 
         public static List<string> ParseStringList(string text, bool replaceCharacters = true)
         {
-            if (text == null || text == "")
+            if (string.IsNullOrEmpty(text))
             {
                 return new List<string>();
             }

--- a/STROOP/Utilities/SkribblioUtilities.cs
+++ b/STROOP/Utilities/SkribblioUtilities.cs
@@ -14,7 +14,7 @@ namespace STROOP.Structs
     public static class SkribblioUtilities
     {
         private static readonly List<string> _words =
-            new List<string>()
+            new List<string>
             {
                 // Mission Names
                 "Big Bob-omb on the Summit",
@@ -962,7 +962,7 @@ namespace STROOP.Structs
                 "Bounce",
                 "Adventure",
                 "Knock",
-                "Linguine",
+                "Linguine"
             };
 
         public static void ShowWords()

--- a/STROOP/Utilities/Stream/DolphinProcessIO.cs
+++ b/STROOP/Utilities/Stream/DolphinProcessIO.cs
@@ -58,7 +58,7 @@ namespace STROOP.Utilities
                 }
             }
             if (_baseOffset.ToUInt64() == 0)
-                throw new ArgumentNullException("Dolphin running, but emulator hasn't started");
+              throw new InvalidOperationException("Dolphin running, but emulator hasn't started");
 
             _baseOffset = (UIntPtr)(_baseOffset.ToUInt64() + _emulator.RamStart);
         }

--- a/STROOP/Utilities/Stream/ProcessStream.cs
+++ b/STROOP/Utilities/Stream/ProcessStream.cs
@@ -57,7 +57,7 @@ namespace STROOP.Utilities
         {
             try
             {
-                var log = String.Format("{0}\n{1}\n{2}\n", e.Message, e.TargetSite.ToString(), e.StackTrace);
+                var log = String.Format("{0}\n{1}\n{2}\n", e.Message, e.TargetSite, e.StackTrace);
                 File.AppendAllText("error.txt", log);
             }
             catch (Exception) { }
@@ -69,10 +69,10 @@ namespace STROOP.Utilities
             throw obj.Exception;
         }
 
-        private readonly Dictionary<Type, Func<Process, Emulator, IEmuRamIO>> _ioCreationTable = new Dictionary<Type, Func<Process, Emulator, IEmuRamIO>>()
+        private readonly Dictionary<Type, Func<Process, Emulator, IEmuRamIO>> _ioCreationTable = new Dictionary<Type, Func<Process, Emulator, IEmuRamIO>>
         {
             { typeof(WindowsProcessRamIO),  (p, e) => new WindowsProcessRamIO(p, e) },
-            { typeof(DolphinProcessIO),     (p, e) => new DolphinProcessIO(p, e) },
+            { typeof(DolphinProcessIO),     (p, e) => new DolphinProcessIO(p, e) }
         };
 
         [DllImport("user32.dll")]

--- a/STROOP/Utilities/Stream/WindowsProcessIO.cs
+++ b/STROOP/Utilities/Stream/WindowsProcessIO.cs
@@ -79,7 +79,7 @@ namespace STROOP.Utilities
                     ?.FirstOrDefault(d => d.ModuleName == _emulator.Dll);
 
                 if (dll == null)
-                    throw new ArgumentNullException("Could not find ");
+                    throw new ArgumentNullException("dll");
 
                 dllOffset = dll.BaseAddress;
             }

--- a/STROOP/Utilities/TestUtilities.cs
+++ b/STROOP/Utilities/TestUtilities.cs
@@ -38,7 +38,7 @@ namespace STROOP.Utilities
 
         public static void TestSomething25()
         {
-            List<double> doubleList = new List<double>()
+            List<double> doubleList = new List<double>
             {
                 2,
                 5.94287109375,
@@ -50,7 +50,7 @@ namespace STROOP.Utilities
                 73.255859375,
                 75.255859375,
                 77.255859375,
-                79.255859375,
+                79.255859375
             };
 
             int startX = 6765;
@@ -85,7 +85,7 @@ namespace STROOP.Utilities
             int range = 100;
             int range2 = 10000;
 
-            List<int> goodAngles = new List<int>() { 27408, 27424, 27440, 27456, 27472 };
+            List<int> goodAngles = new List<int> { 27408, 27424, 27440, 27456, 27472 };
 
             for (int i = 0; i < range; i++)
             {
@@ -165,7 +165,7 @@ namespace STROOP.Utilities
 
         public static void TestSomething18()
         {
-            List<int> initialAngles = new List<int>() { 22976, 22592, 22512 };
+            List<int> initialAngles = new List<int> { 22976, 22592, 22512 };
 
             int range = 10;
             List<int> extendedAngles = new List<int>();
@@ -212,7 +212,7 @@ namespace STROOP.Utilities
 
         public static void TestSomething17()
         {
-            List<int> initialAngles = new List<int>()
+            List<int> initialAngles = new List<int>
             {
                 88527,
                 88052,
@@ -252,9 +252,9 @@ namespace STROOP.Utilities
                 -43017,
                 -305162,
                 -108558,
-                219125,
+                219125
             };
-            List<int> initialAccMags = new List<int>() { 13, 42 };
+            List<int> initialAccMags = new List<int> { 13, 42 };
 
             string output = "";
             foreach (int initialAngle in initialAngles)
@@ -460,10 +460,10 @@ namespace STROOP.Utilities
 
             public List<PendulumSwing> GetSuccessors()
             {
-                return new List<PendulumSwing>()
+                return new List<PendulumSwing>
                 {
                     new PendulumSwing((int)WatchVariableSpecialUtilities.GetPendulumAmplitude(Amplitude, 13), 13, this),
-                    new PendulumSwing((int)WatchVariableSpecialUtilities.GetPendulumAmplitude(Amplitude, 42), 42, this),
+                    new PendulumSwing((int)WatchVariableSpecialUtilities.GetPendulumAmplitude(Amplitude, 42), 42, this)
                 };
             }
 
@@ -483,11 +483,11 @@ namespace STROOP.Utilities
             uint triangleAddress = Config.TriangleManager.TriangleAddress;
             if (triangleAddress == 0) return;
             TriangleDataModel triangle = new TriangleDataModel(triangleAddress);
-            List<List<short>> triangleVertices = new List<List<short>>()
+            List<List<short>> triangleVertices = new List<List<short>>
             {
-                new List<short>() { triangle.X1, triangle.Y1, triangle.Z1 },
-                new List<short>() { triangle.X2, triangle.Y2, triangle.Z2 },
-                new List<short>() { triangle.X3, triangle.Y3, triangle.Z3 },
+                new List<short> { triangle.X1, triangle.Y1, triangle.Z1 },
+                new List<short> { triangle.X2, triangle.Y2, triangle.Z2 },
+                new List<short> { triangle.X3, triangle.Y3, triangle.Z3 }
             };
 
             int structSize = numVertices * 0x10;
@@ -546,7 +546,7 @@ namespace STROOP.Utilities
                                 invertBool: null,
                                 isYaw: null,
                                 coordinate: null,
-                                groupList: new List<VariableGroup>() { VariableGroup.Custom });
+                                groupList: new List<VariableGroup> { VariableGroup.Custom });
                             precursors.Add(precursor);
                         }
 
@@ -637,7 +637,7 @@ namespace STROOP.Utilities
         {
             List<VariableAdder> variableAdderList = Config.GetVariableAdders();
             string output = "";
-            variableAdderList.ForEach(varAdder => output += varAdder.ToString() + " " + varAdder.TabIndex + "\r\n");
+            variableAdderList.ForEach(varAdder => output += varAdder + " " + varAdder.TabIndex + "\r\n");
             InfoForm.ShowValue(output);
         }
 
@@ -651,7 +651,7 @@ namespace STROOP.Utilities
             InfoForm.ShowValue(String.Join("\r\n", output));
         }
 
-        public static List<double> marioPositions1 = new List<double>()
+        public static List<double> marioPositions1 = new List<double>
         {
             -5625.607422,-5598.169922,-5570.271484,-5541.921875,-5513.130859,-5483.910156,-5454.267578,
             -5424.214844,-5393.761719,-5362.916016,-5331.6875,-5300.085938,-5268.119141,-5235.794922,
@@ -666,10 +666,10 @@ namespace STROOP.Utilities
             -3430.87793,-3399.107422,-3366.975586,-3335.84375,-3304.335938,-3272.460938,-3240.227539,
             -3208.994141,-3177.386719,-3145.415039,-3113.086914,-3081.758789,-3050.058594,-3017.996094,
             -2986.933594,-2955.493164,-2923.683594,-2891.513672,-2860.34375,-2828.798828,-2796.887695,
-            -2764.619141,-2733.350586,-2701.708984,-2669.703125,-2638.697266,-2638.697266,
+            -2764.619141,-2733.350586,-2701.708984,-2669.703125,-2638.697266,-2638.697266
         };
 
-        public static List<double> marioPositions2 = new List<double>()
+        public static List<double> marioPositions2 = new List<double>
         {
             -5575.169922,-5547.271484,-5518.921875,-5490.130859,-5460.910156,-5431.267578,
             -5401.214844,-5370.761719,-5339.916016,-5308.6875,-5277.085938,-5245.119141,-5212.794922,
@@ -680,7 +680,7 @@ namespace STROOP.Utilities
             -4294.425781,-4263.378906,-4231.953125,-4200.158203,-4168.003906,-4136.849609,-4105.318359,
             -4073.421143,-4041.165283,-4009.909424,-3978.280518,-3946.287354,-3913.938721,-3882.590088,
             -3850.870361,-3818.78833,-3787.706299,-3756.247314,-3724.419189,-3692.231689,-3661.044189,
-            -3629.481689,-3597.552979,-3565.266846,-3533.980713,-3502.32251,-3470.300049,-3439.277588,
+            -3629.481689,-3597.552979,-3565.266846,-3533.980713,-3502.32251,-3470.300049,-3439.277588
         };
 
         public static void TestScuttlebugDrops()
@@ -785,7 +785,7 @@ namespace STROOP.Utilities
             }
         }
 
-        private static List<int[]> unitCoordinates_ = new List<int[]>()
+        private static List<int[]> unitCoordinates_ = new List<int[]>
         {
             new int[] {5,13},
             new int[] {5,12},
@@ -848,7 +848,7 @@ namespace STROOP.Utilities
             new int[] {4,2},
             new int[] {5,2},
             new int[] {6,2},
-            new int[] {6,1},
+            new int[] {6,1}
         };
     }
 } 

--- a/STROOP/Utilities/TriangleUtilities.cs
+++ b/STROOP/Utilities/TriangleUtilities.cs
@@ -167,11 +167,11 @@ namespace STROOP.Utilities
                 new List<((short, short), (short, short), bool)>();
             foreach (TriangleDataModel wallTriangle in wallTriangles)
             {
-                List<(short, short)> vertices = new List<(short, short)>()
+                List<(short, short)> vertices = new List<(short, short)>
                 {
                     (wallTriangle.X1, wallTriangle.Z1),
                     (wallTriangle.X2, wallTriangle.Z2),
-                    (wallTriangle.X3, wallTriangle.Z3),
+                    (wallTriangle.X3, wallTriangle.Z3)
                 };
 
                 for (int i = 0; i < vertices.Count; i++)
@@ -282,8 +282,8 @@ namespace STROOP.Utilities
         public static (float normX, float normY, float normZ, float normOffset) GetNorms(
             double x1, double y1, double z1, double x2, double y2, double z2, double x3, double y3, double z3)
         {
-            List<double> v12 = new List<double>() { x2 - x1, y2 - y1, z2 - z1 };
-            List<double> v13 = new List<double>() { x3 - x1, y3 - y1, z3 - z1 };
+            List<double> v12 = new List<double> { x2 - x1, y2 - y1, z2 - z1 };
+            List<double> v13 = new List<double> { x3 - x1, y3 - y1, z3 - z1 };
 
             double normXUnscaled = v12[1] * v13[2] - v12[2] * v13[1];
             double normYUnscaled = v12[2] * v13[0] - v12[0] * v13[2];

--- a/STROOP/Utilities/TtcSpeedSettingUtilities.cs
+++ b/STROOP/Utilities/TtcSpeedSettingUtilities.cs
@@ -54,12 +54,12 @@ namespace STROOP.Structs
 
         public static List<string> GetDescriptions()
         {
-            return new List<string>()
+            return new List<string>
             {
                 "Slow",
                 "Fast",
                 "Random",
-                "Still",
+                "Still"
             };
         }
 

--- a/STROOP/Utilities/TypeUtilities.cs
+++ b/STROOP/Utilities/TypeUtilities.cs
@@ -13,7 +13,7 @@ namespace STROOP.Structs
 {
     public static class TypeUtilities
     {
-        public readonly static Dictionary<string, Type> StringToType = new Dictionary<string, Type>()
+        public readonly static Dictionary<string, Type> StringToType = new Dictionary<string, Type>
         {
             { "byte", typeof(byte) },
             { "sbyte", typeof(sbyte) },
@@ -24,10 +24,10 @@ namespace STROOP.Structs
             { "long", typeof(long) },
             { "ulong", typeof(ulong) },
             { "float", typeof(float) },
-            { "double", typeof(double) },
+            { "double", typeof(double) }
         };
 
-        public readonly static Dictionary<Type, string> TypeToString = new Dictionary<Type, string>()
+        public readonly static Dictionary<Type, string> TypeToString = new Dictionary<Type, string>
         {
             { typeof(byte), "byte" },
             { typeof(sbyte), "sbyte" },
@@ -38,10 +38,10 @@ namespace STROOP.Structs
             { typeof(long), "long" },
             { typeof(ulong), "ulong" },
             { typeof(float), "float" },
-            { typeof(double), "double" },
+            { typeof(double), "double" }
         };
 
-        public readonly static Dictionary<Type, int> TypeSize = new Dictionary<Type, int>()
+        public readonly static Dictionary<Type, int> TypeSize = new Dictionary<Type, int>
         {
             {typeof(byte), 1},
             {typeof(sbyte), 1},
@@ -52,10 +52,10 @@ namespace STROOP.Structs
             {typeof(long), 8},
             {typeof(ulong), 8},
             {typeof(float), 4},
-            {typeof(double), 8},
+            {typeof(double), 8}
         };
 
-        public readonly static Dictionary<Type, bool> TypeSign = new Dictionary<Type, bool>()
+        public readonly static Dictionary<Type, bool> TypeSign = new Dictionary<Type, bool>
         {
             {typeof(byte), false},
             {typeof(sbyte), true},
@@ -66,19 +66,19 @@ namespace STROOP.Structs
             {typeof(long), true},
             {typeof(ulong), false},
             {typeof(float), true},
-            {typeof(double), true},
+            {typeof(double), true}
         };
 
-        public readonly static Dictionary<int, Type> UnsignedByteType = new Dictionary<int, Type>()
+        public readonly static Dictionary<int, Type> UnsignedByteType = new Dictionary<int, Type>
         {
             {1, typeof(byte)},
             {2, typeof(ushort)},
             {4, typeof(uint)},
-            {8, typeof(ulong)},
+            {8, typeof(ulong)}
         };
 
         public readonly static List<string> SimpleTypeList =
-            new List<string>()
+            new List<string>
             {
                 "byte",
                 "sbyte",
@@ -86,11 +86,11 @@ namespace STROOP.Structs
                 "ushort",
                 "int",
                 "uint",
-                "float",
+                "float"
             };
 
         public readonly static List<string> InGameTypeList =
-            new List<string>()
+            new List<string>
             {
                 "byte",
                 "sbyte",
@@ -99,7 +99,7 @@ namespace STROOP.Structs
                 "int",
                 "uint",
                 "float",
-                "double",
+                "double"
             };
 
         public static object ConvertBytes(Type type, string hexString, bool littleEndian)

--- a/STROOP/Utilities/VarHackSpecialUtilities.cs
+++ b/STROOP/Utilities/VarHackSpecialUtilities.cs
@@ -54,18 +54,12 @@ namespace STROOP.Structs
 
                 case "MarioAction":
                     name = "Action " + VarHackConfig.EscapeChar;
-                    getterFunction = () =>
-                    {
-                        return TableConfig.MarioActions.GetActionName();
-                    };
+                    getterFunction = TableConfig.MarioActions.GetActionName;
                     break;
 
                 case "MarioAnimation":
                     name = "Animation " + VarHackConfig.EscapeChar;
-                    getterFunction = () =>
-                    {
-                        return TableConfig.MarioAnimations.GetAnimationName();
-                    };
+                    getterFunction = TableConfig.MarioAnimations.GetAnimationName;
                     break;
 
                 case "DYawIntendFacing":
@@ -82,9 +76,6 @@ namespace STROOP.Structs
                     {
                         return FormatInteger(WatchVariableSpecialUtilities.GetDeltaYawIntendedFacing() / 16);
                     };
-                    break;
-
-                default:
                     break;
             }
 

--- a/STROOP/Utilities/WatchVariableSelectionUtilities.cs
+++ b/STROOP/Utilities/WatchVariableSelectionUtilities.cs
@@ -34,16 +34,16 @@ namespace STROOP.Structs
             ToolStripMenuItem itemHighlight = new ToolStripMenuItem("Highlight...");
             ControlUtilities.AddDropDownItems(
                 itemHighlight,
-                new List<string>() { "Highlight", "Don't Highlight" },
-                new List<Action>()
+                new List<string> { "Highlight", "Don't Highlight" },
+                new List<Action>
                 {
                     () => apply(new WatchVariableControlSettings(changeHighlighted: true, newHighlighted: true)),
-                    () => apply(new WatchVariableControlSettings(changeHighlighted: true, newHighlighted: false)),
+                    () => apply(new WatchVariableControlSettings(changeHighlighted: true, newHighlighted: false))
                 });
             ToolStripMenuItem itemHighlightColor = new ToolStripMenuItem("Color...");
             ControlUtilities.AddDropDownItems(
                 itemHighlightColor,
-                new List<string>()
+                new List<string>
                 {
                     "Red",
                     "Orange",
@@ -54,9 +54,9 @@ namespace STROOP.Structs
                     "Pink",
                     "Brown",
                     "Black",
-                    "White",
+                    "White"
                 },
-                new List<Action>()
+                new List<Action>
                 {
                     () => apply(new WatchVariableControlSettings(changeHighlightColor: true, newHighlightColor: Color.Red)),
                     () => apply(new WatchVariableControlSettings(changeHighlightColor: true, newHighlightColor: Color.Orange)),
@@ -67,29 +67,29 @@ namespace STROOP.Structs
                     () => apply(new WatchVariableControlSettings(changeHighlightColor: true, newHighlightColor: Color.Pink)),
                     () => apply(new WatchVariableControlSettings(changeHighlightColor: true, newHighlightColor: Color.Brown)),
                     () => apply(new WatchVariableControlSettings(changeHighlightColor: true, newHighlightColor: Color.Black)),
-                    () => apply(new WatchVariableControlSettings(changeHighlightColor: true, newHighlightColor: Color.White)),
+                    () => apply(new WatchVariableControlSettings(changeHighlightColor: true, newHighlightColor: Color.White))
                 });
             itemHighlight.DropDownItems.Add(itemHighlightColor);
 
             ToolStripMenuItem itemLock = new ToolStripMenuItem("Lock...");
             ControlUtilities.AddDropDownItems(
                 itemLock,
-                new List<string>() { "Lock", "Don't Lock" },
-                new List<Action>()
+                new List<string> { "Lock", "Don't Lock" },
+                new List<Action>
                 {
                     () => apply(new WatchVariableControlSettings(changeLocked: true, newLocked: true)),
-                    () => apply(new WatchVariableControlSettings(changeLocked: true, newLocked: false)),
+                    () => apply(new WatchVariableControlSettings(changeLocked: true, newLocked: false))
                 });
 
             ToolStripMenuItem itemFixAddress = new ToolStripMenuItem("Fix Address...");
             ControlUtilities.AddDropDownItems(
                 itemFixAddress,
-                new List<string>() { "Default", "Fix Address", "Don't Fix Address" },
-                new List<Action>()
+                new List<string> { "Default", "Fix Address", "Don't Fix Address" },
+                new List<Action>
                 {
                     () => apply(new WatchVariableControlSettings(changeFixedAddress: true, changeFixedAddressToDefault: true)),
                     () => apply(new WatchVariableControlSettings(changeFixedAddress: true, newFixedAddress: true)),
-                    () => apply(new WatchVariableControlSettings(changeFixedAddress: true, newFixedAddress: false)),
+                    () => apply(new WatchVariableControlSettings(changeFixedAddress: true, newFixedAddress: false))
                 });
 
             ToolStripMenuItem itemCopy = new ToolStripMenuItem("Copy...");
@@ -200,23 +200,23 @@ namespace STROOP.Structs
             ToolStripMenuItem itemDisplayAsHex = new ToolStripMenuItem("Display as Hex...");
             ControlUtilities.AddDropDownItems(
                 itemDisplayAsHex,
-                new List<string>() { "Default", "Hex", "Decimal" },
-                new List<Action>()
+                new List<string> { "Default", "Hex", "Decimal" },
+                new List<Action>
                 {
                     () => apply(new WatchVariableControlSettings(changeDisplayAsHex: true, changeDisplayAsHexToDefault: true)),
                     () => apply(new WatchVariableControlSettings(changeDisplayAsHex: true, newDisplayAsHex: true)),
-                    () => apply(new WatchVariableControlSettings(changeDisplayAsHex: true, newDisplayAsHex: false)),
+                    () => apply(new WatchVariableControlSettings(changeDisplayAsHex: true, newDisplayAsHex: false))
                 });
 
             ToolStripMenuItem itemAngleSigned = new ToolStripMenuItem("Angle: Signed...");
             ControlUtilities.AddDropDownItems(
                 itemAngleSigned,
-                new List<string>() { "Default", "Unsigned", "Signed" },
-                new List<Action>()
+                new List<string> { "Default", "Unsigned", "Signed" },
+                new List<Action>
                 {
                     () => apply(new WatchVariableControlSettings(changeAngleSigned: true, changeAngleSignedToDefault: true)),
                     () => apply(new WatchVariableControlSettings(changeAngleSigned: true, newAngleSigned: false)),
-                    () => apply(new WatchVariableControlSettings(changeAngleSigned: true, newAngleSigned: true)),
+                    () => apply(new WatchVariableControlSettings(changeAngleSigned: true, newAngleSigned: true))
                 });
 
             ToolStripMenuItem itemAngleUnits = new ToolStripMenuItem("Angle: Units...");
@@ -245,45 +245,45 @@ namespace STROOP.Structs
             ToolStripMenuItem itemAngleTruncateToMultipleOf16 = new ToolStripMenuItem("Angle: Truncate to Multiple of 16...");
             ControlUtilities.AddDropDownItems(
                 itemAngleTruncateToMultipleOf16,
-                new List<string>() { "Default", "Truncate to Multiple of 16", "Don't Truncate to Multiple of 16" },
-                new List<Action>()
+                new List<string> { "Default", "Truncate to Multiple of 16", "Don't Truncate to Multiple of 16" },
+                new List<Action>
                 {
                     () => apply(new WatchVariableControlSettings(changeAngleTruncateToMultipleOf16: true, changeAngleTruncateToMultipleOf16ToDefault: true)),
                     () => apply(new WatchVariableControlSettings(changeAngleTruncateToMultipleOf16: true, newAngleTruncateToMultipleOf16: true)),
-                    () => apply(new WatchVariableControlSettings(changeAngleTruncateToMultipleOf16: true, newAngleTruncateToMultipleOf16: false)),
+                    () => apply(new WatchVariableControlSettings(changeAngleTruncateToMultipleOf16: true, newAngleTruncateToMultipleOf16: false))
                 });
 
             ToolStripMenuItem itemAngleConstrainToOneRevolution = new ToolStripMenuItem("Angle: Constrain to One Revolution...");
             ControlUtilities.AddDropDownItems(
                 itemAngleConstrainToOneRevolution,
-                new List<string>() { "Default", "Constrain to One Revolution", "Don't Constrain to One Revolution" },
-                new List<Action>()
+                new List<string> { "Default", "Constrain to One Revolution", "Don't Constrain to One Revolution" },
+                new List<Action>
                 {
                     () => apply(new WatchVariableControlSettings(changeAngleConstrainToOneRevolution: true, changeAngleConstrainToOneRevolutionToDefault: true)),
                     () => apply(new WatchVariableControlSettings(changeAngleConstrainToOneRevolution: true, newAngleConstrainToOneRevolution: true)),
-                    () => apply(new WatchVariableControlSettings(changeAngleConstrainToOneRevolution: true, newAngleConstrainToOneRevolution: false)),
+                    () => apply(new WatchVariableControlSettings(changeAngleConstrainToOneRevolution: true, newAngleConstrainToOneRevolution: false))
                 });
 
             ToolStripMenuItem itemAngleReverse = new ToolStripMenuItem("Angle: Reverse...");
             ControlUtilities.AddDropDownItems(
                 itemAngleReverse,
-                new List<string>() { "Default", "Reverse", "Don't Reverse" },
-                new List<Action>()
+                new List<string> { "Default", "Reverse", "Don't Reverse" },
+                new List<Action>
                 {
                     () => apply(new WatchVariableControlSettings(changeAngleReverse: true, changeAngleReverseToDefault: true)),
                     () => apply(new WatchVariableControlSettings(changeAngleReverse: true, newAngleReverse: true)),
-                    () => apply(new WatchVariableControlSettings(changeAngleReverse: true, newAngleReverse: false)),
+                    () => apply(new WatchVariableControlSettings(changeAngleReverse: true, newAngleReverse: false))
                 });
 
             ToolStripMenuItem itemAngleDisplayAsHex = new ToolStripMenuItem("Angle: Display as Hex...");
             ControlUtilities.AddDropDownItems(
                 itemAngleDisplayAsHex,
-                new List<string>() { "Default", "Hex", "Decimal" },
-                new List<Action>()
+                new List<string> { "Default", "Hex", "Decimal" },
+                new List<Action>
                 {
                     () => apply(new WatchVariableControlSettings(changeAngleDisplayAsHex: true, changeAngleDisplayAsHexToDefault: true)),
                     () => apply(new WatchVariableControlSettings(changeAngleDisplayAsHex: true, newAngleDisplayAsHex: true)),
-                    () => apply(new WatchVariableControlSettings(changeAngleDisplayAsHex: true, newAngleDisplayAsHex: false)),
+                    () => apply(new WatchVariableControlSettings(changeAngleDisplayAsHex: true, newAngleDisplayAsHex: false))
                 });
 
             ToolStripMenuItem itemShowVariableXml = new ToolStripMenuItem("Show Variable XML");
@@ -356,19 +356,19 @@ namespace STROOP.Structs
             ToolStripMenuItem itemAddVariables = new ToolStripMenuItem("Add Variable(s)...");
             ControlUtilities.AddDropDownItems(
                 itemAddVariables,
-                new List<string>()
+                new List<string>
                 {
                     "Addition",
                     "Subtraction",
                     "Multiplication",
-                    "Division",
+                    "Division"
                 },
-                new List<Action>()
+                new List<Action>
                 {
                     () => createVariable(MathOperation.Add),
                     () => createVariable(MathOperation.Subtract),
                     () => createVariable(MathOperation.Multiply),
-                    () => createVariable(MathOperation.Divide),
+                    () => createVariable(MathOperation.Divide)
                 });
 
             ToolStripMenuItem itemSetCascadingValues = new ToolStripMenuItem("Set Cascading Values");
@@ -429,12 +429,12 @@ namespace STROOP.Structs
             ToolStripMenuItem itemMove = new ToolStripMenuItem("Move...");
             ControlUtilities.AddDropDownItems(
                 itemMove,
-                new List<string>() { "Start Move", "End Move", "Clear Move" },
-                new List<Action>()
+                new List<string> { "Start Move", "End Move", "Clear Move" },
+                new List<Action>
                 {
                     () => panel.NotifyOfReorderingStart(getVars()),
                     () => panel.NotifyOfReorderingEnd(getVars()),
-                    () => panel.NotifyOfReorderingClear(),
+                    panel.NotifyOfReorderingClear
                 });
 
             ToolStripMenuItem itemRemove = new ToolStripMenuItem("Remove");
@@ -486,7 +486,7 @@ namespace STROOP.Structs
             ToolStripMenuItem itemAddToCustomTab = new ToolStripMenuItem("Add to Custom Tab");
             itemAddToCustomTab.Click += (sender, e) => WatchVariableControl.AddVarsToTab(getVars(), Config.CustomManager);
 
-            return new List<ToolStripItem>()
+            return new List<ToolStripItem>
             {
                 itemHighlight,
                 itemLock,
@@ -518,7 +518,7 @@ namespace STROOP.Structs
                 itemOpenTripletController,
                 itemOpenPopOut,
                 itemAddToTab,
-                itemAddToCustomTab,
+                itemAddToCustomTab
             };
         }
         

--- a/STROOP/Utilities/WatchVariableSpecialUtilities.cs
+++ b/STROOP/Utilities/WatchVariableSpecialUtilities.cs
@@ -164,14 +164,14 @@ namespace STROOP.Structs
         public static void AddPanEntriesToDictionary()
         {
             List<(string, Func<double>, Action<double>)> entries =
-                new List<(string, Func<double>, Action<double>)>()
+                new List<(string, Func<double>, Action<double>)>
                 {
                     ("NumPans", () => SpecialConfig.NumPans, (double value) => SpecialConfig.NumPans = value),
                     ("CurrentPan", () => SpecialConfig.CurrentPan, (double value) => {}),
                     ("PanCamPos", () => SpecialConfig.PanCamPos, (double value) => SpecialConfig.PanCamPos = value),
                     ("PanCamAngle", () => SpecialConfig.PanCamAngle, (double value) => SpecialConfig.PanCamAngle = value),
                     ("PanCamRotation", () => SpecialConfig.PanCamRotation, (double value) => SpecialConfig.PanCamRotation = value),
-                    ("PanFOV", () => SpecialConfig.PanFOV, (double value) => SpecialConfig.PanFOV = value),
+                    ("PanFOV", () => SpecialConfig.PanFOV, (double value) => SpecialConfig.PanFOV = value)
                 };
 
             foreach ((string key, Func<double> getter, Action<double> setter) in entries)
@@ -192,7 +192,7 @@ namespace STROOP.Structs
         public static void AddPanEntriesToDictionary(int index)
         {
             List<(string, Func<double>, Action<double>)> entries =
-                new List<(string, Func<double>, Action<double>)>()
+                new List<(string, Func<double>, Action<double>)>
                 {
                     (String.Format("Pan{0}GlobalTimer", index), () => SpecialConfig.PanModels[index].PanGlobalTimer, (double value) => SpecialConfig.PanModels[index].PanGlobalTimer = value),
                     (String.Format("Pan{0}StartTime", index), () => SpecialConfig.PanModels[index].PanStartTime, (double value) => SpecialConfig.PanModels[index].PanStartTime = value),
@@ -221,7 +221,7 @@ namespace STROOP.Structs
                     (String.Format("Pan{0}RadiusEnd", index), () => SpecialConfig.PanModels[index].PanRadiusEnd, (double value) => SpecialConfig.PanModels[index].PanRadiusEnd = value),
 
                     (String.Format("Pan{0}FOVStart", index), () => SpecialConfig.PanModels[index].PanFOVStart, (double value) => SpecialConfig.PanModels[index].PanFOVStart = value),
-                    (String.Format("Pan{0}FOVEnd", index), () => SpecialConfig.PanModels[index].PanFOVEnd, (double value) => SpecialConfig.PanModels[index].PanFOVEnd = value),
+                    (String.Format("Pan{0}FOVEnd", index), () => SpecialConfig.PanModels[index].PanFOVEnd, (double value) => SpecialConfig.PanModels[index].PanFOVEnd = value)
                 };
 
             foreach ((string key, Func<double> getter, Action<double> setter) in entries)
@@ -242,7 +242,7 @@ namespace STROOP.Structs
         public static void AddMap3DEntriesToDictionary()
         {
             List<(string, Func<float>, Action<float>)> doubleEntries =
-                new List<(string, Func<float>, Action<float>)>()
+                new List<(string, Func<float>, Action<float>)>
                 {
                     ("Map3DCameraX", () => SpecialConfig.Map3DCameraX, (float value) => SpecialConfig.Map3DCameraX = value),
                     ("Map3DCameraY", () => SpecialConfig.Map3DCameraY, (float value) => SpecialConfig.Map3DCameraY = value),
@@ -256,7 +256,7 @@ namespace STROOP.Structs
                     ("Map3DFollowingRadius", () => SpecialConfig.Map3DFollowingRadius, (float value) => SpecialConfig.Map3DFollowingRadius = value),
                     ("Map3DFollowingYOffset", () => SpecialConfig.Map3DFollowingYOffset, (float value) => SpecialConfig.Map3DFollowingYOffset = value),
                     ("Map3DFollowingYaw", () => SpecialConfig.Map3DFollowingYaw, (float value) => SpecialConfig.Map3DFollowingYaw = value),
-                    ("Map3DFOV", () => SpecialConfig.Map3DFOV, (float value) => SpecialConfig.Map3DFOV = value),
+                    ("Map3DFOV", () => SpecialConfig.Map3DFOV, (float value) => SpecialConfig.Map3DFOV = value)
                 };
 
             foreach ((string key, Func<float> getter, Action<float> setter) in doubleEntries)
@@ -275,12 +275,12 @@ namespace STROOP.Structs
             }
 
             List<(string, Func<string>, Action<PositionAngle>)> posAngleEntries =
-                new List<(string, Func<string>, Action<PositionAngle>)>()
+                new List<(string, Func<string>, Action<PositionAngle>)>
                 {
                     ("Map3DCameraPosPA", () => SpecialConfig.Map3DCameraPosPA.ToString(), (PositionAngle value) => SpecialConfig.Map3DCameraPosPA = value),
                     ("Map3DCameraAnglePA", () => SpecialConfig.Map3DCameraAnglePA.ToString(), (PositionAngle value) => SpecialConfig.Map3DCameraAnglePA = value),
                     ("Map3DFocusPosPA", () => SpecialConfig.Map3DFocusPosPA.ToString(), (PositionAngle value) => SpecialConfig.Map3DFocusPosPA = value),
-                    ("Map3DFocusAnglePA", () => SpecialConfig.Map3DFocusAnglePA.ToString(), (PositionAngle value) => SpecialConfig.Map3DFocusAnglePA = value),
+                    ("Map3DFocusAnglePA", () => SpecialConfig.Map3DFocusAnglePA.ToString(), (PositionAngle value) => SpecialConfig.Map3DFocusAnglePA = value)
                 };
 
             foreach ((string key, Func<string> getter, Action<PositionAngle> setter) in posAngleEntries)
@@ -319,7 +319,7 @@ namespace STROOP.Structs
         public static void AddGeneratedEntriesToDictionary()
         {
             List<Func<uint, PositionAngle>> posAngleFuncs =
-                new List<Func<uint, PositionAngle>>()
+                new List<Func<uint, PositionAngle>>
                 {
                     (uint address) => PositionAngle.Custom,
                     (uint address) => PositionAngle.Mario,
@@ -332,11 +332,11 @@ namespace STROOP.Structs
                     (uint address) => PositionAngle.Tri(address, 2),
                     (uint address) => PositionAngle.Tri(address, 3),
                     (uint address) => SpecialConfig.PointPA,
-                    (uint address) => SpecialConfig.SelfPA,
+                    (uint address) => SpecialConfig.SelfPA
                 };
 
             List<string> posAngleStrings =
-                new List<string>()
+                new List<string>
                 {
                     "Custom",
                     "Mario",
@@ -349,7 +349,7 @@ namespace STROOP.Structs
                     "TriV2",
                     "TriV3",
                     "Point",
-                    "Self",
+                    "Self"
                 };
 
             for (int i = 0; i < posAngleFuncs.Count; i++)
@@ -363,9 +363,9 @@ namespace STROOP.Structs
                     Func<uint, PositionAngle> func2 = posAngleFuncs[j];
                     string string2 = posAngleStrings[j];
 
-                    List<string> distTypes = new List<string>() { "X", "Y", "Z", "H", "", "F", "S" };
+                    List<string> distTypes = new List<string> { "X", "Y", "Z", "H", "", "F", "S" };
                     List<Func<PositionAngle, PositionAngle, double>> distGetters =
-                        new List<Func<PositionAngle, PositionAngle, double>>()
+                        new List<Func<PositionAngle, PositionAngle, double>>
                         {
                             (PositionAngle p1, PositionAngle p2) => PositionAngle.GetXDistance(p1, p2),
                             (PositionAngle p1, PositionAngle p2) => PositionAngle.GetYDistance(p1, p2),
@@ -373,10 +373,10 @@ namespace STROOP.Structs
                             (PositionAngle p1, PositionAngle p2) => PositionAngle.GetHDistance(p1, p2),
                             (PositionAngle p1, PositionAngle p2) => PositionAngle.GetDistance(p1, p2),
                             (PositionAngle p1, PositionAngle p2) => PositionAngle.GetFDistance(p1, p2),
-                            (PositionAngle p1, PositionAngle p2) => PositionAngle.GetSDistance(p1, p2),
+                            (PositionAngle p1, PositionAngle p2) => PositionAngle.GetSDistance(p1, p2)
                         };
                     List<Func<PositionAngle, PositionAngle, double, bool>> distSetters =
-                        new List<Func<PositionAngle, PositionAngle, double, bool>>()
+                        new List<Func<PositionAngle, PositionAngle, double, bool>>
                         {
                             (PositionAngle p1, PositionAngle p2, double dist) => PositionAngle.SetXDistance(p1, p2, dist),
                             (PositionAngle p1, PositionAngle p2, double dist) => PositionAngle.SetYDistance(p1, p2, dist),
@@ -384,7 +384,7 @@ namespace STROOP.Structs
                             (PositionAngle p1, PositionAngle p2, double dist) => PositionAngle.SetHDistance(p1, p2, dist),
                             (PositionAngle p1, PositionAngle p2, double dist) => PositionAngle.SetDistance(p1, p2, dist),
                             (PositionAngle p1, PositionAngle p2, double dist) => PositionAngle.SetFDistance(p1, p2, dist),
-                            (PositionAngle p1, PositionAngle p2, double dist) => PositionAngle.SetSDistance(p1, p2, dist),
+                            (PositionAngle p1, PositionAngle p2, double dist) => PositionAngle.SetSDistance(p1, p2, dist)
                         };
 
                     for (int k = 0; k < distTypes.Count; k++)
@@ -2457,7 +2457,7 @@ namespace STROOP.Structs
                 (double angleDiff, uint triAddress) =>
                 {
                     PositionAngle marioPos = PositionAngle.Mario;
-                    TriangleDataModel triStruct = Config.TriangleManager.GetTriangleStruct(triAddress);;
+                    TriangleDataModel triStruct = Config.TriangleManager.GetTriangleStruct(triAddress);
                     double angleV1ToV2 = MoreMath.AngleTo_AngleUnits(
                         triStruct.X1, triStruct.Z1, triStruct.X2, triStruct.Z2);
                     double newMarioAngleDouble = angleV1ToV2 + angleDiff;
@@ -4044,42 +4044,42 @@ namespace STROOP.Structs
             {
                 Config.Stream.GetSingle(MarioConfig.StructAddress + MarioConfig.XOffset),
                 Config.Stream.GetSingle(MarioConfig.StructAddress + MarioConfig.YOffset),
-                Config.Stream.GetSingle(MarioConfig.StructAddress + MarioConfig.ZOffset),
+                Config.Stream.GetSingle(MarioConfig.StructAddress + MarioConfig.ZOffset)
             };
 
             float[] platformPos = new float[]
             {
                 Config.Stream.GetSingle(stoodOnObject + ObjectConfig.XOffset),
                 Config.Stream.GetSingle(stoodOnObject + ObjectConfig.YOffset),
-                Config.Stream.GetSingle(stoodOnObject + ObjectConfig.ZOffset),
+                Config.Stream.GetSingle(stoodOnObject + ObjectConfig.ZOffset)
             };
 
             float[] currentObjectOffset = new float[]
             {
                 currentObjectPos[0] - platformPos[0],
                 currentObjectPos[1] - platformPos[1],
-                currentObjectPos[2] - platformPos[2],
+                currentObjectPos[2] - platformPos[2]
             };
 
             short[] platformAngularVelocity = new short[]
             {
                 (short)Config.Stream.GetInt32(stoodOnObject + ObjectConfig.PitchVelocityOffset),
                 (short)Config.Stream.GetInt32(stoodOnObject + ObjectConfig.YawVelocityOffset),
-                (short)Config.Stream.GetInt32(stoodOnObject + ObjectConfig.RollVelocityOffset),
+                (short)Config.Stream.GetInt32(stoodOnObject + ObjectConfig.RollVelocityOffset)
             };
 
             short[] platformFacingAngle = new short[]
             {
                 Config.Stream.GetInt16(stoodOnObject + ObjectConfig.PitchFacingOffset),
                 Config.Stream.GetInt16(stoodOnObject + ObjectConfig.YawFacingOffset),
-                Config.Stream.GetInt16(stoodOnObject + ObjectConfig.RollFacingOffset),
+                Config.Stream.GetInt16(stoodOnObject + ObjectConfig.RollFacingOffset)
             };
 
             short[] rotation = new short[]
             {
                 (short)(platformFacingAngle[0] - platformAngularVelocity[0]),
                 (short)(platformFacingAngle[1] - platformAngularVelocity[1]),
-                (short)(platformFacingAngle[2] - platformAngularVelocity[2]),
+                (short)(platformFacingAngle[2] - platformAngularVelocity[2])
             };
 
             float[,] displaceMatrix = new float[4,4];
@@ -4100,7 +4100,7 @@ namespace STROOP.Structs
             {
                 newObjectOffset[0] - currentObjectOffset[0],
                 newObjectOffset[1] - currentObjectOffset[1],
-                newObjectOffset[2] - currentObjectOffset[2],
+                newObjectOffset[2] - currentObjectOffset[2]
             };
 
             return (netDisplacement[0], netDisplacement[1], netDisplacement[2]);

--- a/STROOP/Utilities/WatchVariableUtilities.cs
+++ b/STROOP/Utilities/WatchVariableUtilities.cs
@@ -97,7 +97,7 @@ namespace STROOP.Structs
                 case BaseAddressTypeEnum.Triangle:
                     {
                         uint triangleAddress = Config.TriangleManager.TriangleAddress;
-                        return triangleAddress != 0 ? new List<uint>() { triangleAddress } : BaseAddressListEmpty;
+                        return triangleAddress != 0 ? new List<uint> { triangleAddress } : BaseAddressListEmpty;
                     }
 
                 case BaseAddressTypeEnum.TriangleExertionForceTable:
@@ -111,7 +111,7 @@ namespace STROOP.Structs
                 case BaseAddressTypeEnum.CellsTriangle:
                     {
                         uint triangleAddress = Config.CellsManager.TriangleAddress;
-                        return triangleAddress != 0 ? new List<uint>() { triangleAddress } : BaseAddressListEmpty;
+                        return triangleAddress != 0 ? new List<uint> { triangleAddress } : BaseAddressListEmpty;
                     }
 
                 case BaseAddressTypeEnum.CellsTriangleExertionForceTable:
@@ -125,19 +125,19 @@ namespace STROOP.Structs
                 case BaseAddressTypeEnum.Floor:
                     {
                         uint floorAddress = Config.Stream.GetUInt32(MarioConfig.StructAddress + MarioConfig.FloorTriangleOffset);
-                        return floorAddress != 0 ? new List<uint>() { floorAddress } : BaseAddressListEmpty;
+                        return floorAddress != 0 ? new List<uint> { floorAddress } : BaseAddressListEmpty;
                     }
 
                 case BaseAddressTypeEnum.Wall:
                     {
                         uint wallAddress = Config.Stream.GetUInt32(MarioConfig.StructAddress + MarioConfig.WallTriangleOffset);
-                        return wallAddress != 0 ? new List<uint>() { wallAddress } : BaseAddressListEmpty;
+                        return wallAddress != 0 ? new List<uint> { wallAddress } : BaseAddressListEmpty;
                     }
 
                 case BaseAddressTypeEnum.Ceiling:
                     {
                         uint ceilingAddress = Config.Stream.GetUInt32(MarioConfig.StructAddress + MarioConfig.CeilingTriangleOffset);
-                        return ceilingAddress != 0 ? new List<uint>() { ceilingAddress } : BaseAddressListEmpty;
+                        return ceilingAddress != 0 ? new List<uint> { ceilingAddress } : BaseAddressListEmpty;
                     }
 
                 case BaseAddressTypeEnum.InputCurrent:
@@ -164,7 +164,7 @@ namespace STROOP.Structs
                 case BaseAddressTypeEnum.Water:
                     {
                         uint waterAddress = Config.Stream.GetUInt32(MiscConfig.WaterPointerAddress);
-                        return waterAddress != 0 ? new List<uint>() { waterAddress } : BaseAddressListEmpty;
+                        return waterAddress != 0 ? new List<uint> { waterAddress } : BaseAddressListEmpty;
                     }
 
                 case BaseAddressTypeEnum.Snow:
@@ -176,13 +176,13 @@ namespace STROOP.Structs
                 case BaseAddressTypeEnum.Painting:
                     {
                         uint? paintingAddress = Config.PaintingManager.GetPaintingAddress();
-                        return paintingAddress != null ? new List<uint>() { paintingAddress.Value } : BaseAddressListEmpty;
+                        return paintingAddress != null ? new List<uint> { paintingAddress.Value } : BaseAddressListEmpty;
                     }
 
                 case BaseAddressTypeEnum.Music:
                     {
                         uint? musicAddress = Config.MusicManager.GetMusicAddress();
-                        return musicAddress != null ? new List<uint>() { musicAddress.Value } : BaseAddressListEmpty;
+                        return musicAddress != null ? new List<uint> { musicAddress.Value } : BaseAddressListEmpty;
                     }
 
                 case BaseAddressTypeEnum.LastCoin:
@@ -190,7 +190,7 @@ namespace STROOP.Structs
                         List<uint> coinAddresses = Config.ObjectSlotsManager.GetLoadedObjectsWithPredicate(
                             o => o.BehaviorAssociation?.Name == "Yellow Coin" || o.BehaviorAssociation?.Name == "Blue Coin")
                             .ConvertAll(objectDataModel => objectDataModel.Address);
-                        return coinAddresses.Count > 0 ? new List<uint>() { coinAddresses.Last() } : BaseAddressListEmpty;
+                        return coinAddresses.Count > 0 ? new List<uint> { coinAddresses.Last() } : BaseAddressListEmpty;
                     }
 
                 case BaseAddressTypeEnum.Ghost:
@@ -206,7 +206,7 @@ namespace STROOP.Structs
                 case BaseAddressTypeEnum.GfxNode:
                     {
                         GfxNode node  = Config.GfxManager.SelectedNode;
-                        return node != null ? new List<uint>() { node.Address } : BaseAddressListEmpty;
+                        return node != null ? new List<uint> { node.Address } : BaseAddressListEmpty;
                     }
                 case BaseAddressTypeEnum.GhostHack:
                     return new List<uint>

--- a/STROOP/Utilities/XmlConfigParser.cs
+++ b/STROOP/Utilities/XmlConfigParser.cs
@@ -50,7 +50,7 @@ namespace STROOP.Utilities
             PositionControllerRelativityConfig.CustomAngle = 32768;
 
             // Create schema set
-            var schemaSet = new XmlSchemaSet() { XmlResolver = new ResourceXmlResolver() };
+            var schemaSet = new XmlSchemaSet { XmlResolver = new ResourceXmlResolver() };
             schemaSet.Add("http://tempuri.org/ReusableTypes.xsd", "ReusableTypes.xsd");
             schemaSet.Add("http://tempuri.org/ConfigSchema.xsd", "ConfigSchema.xsd");
             schemaSet.Compile();
@@ -68,7 +68,7 @@ namespace STROOP.Utilities
                         {
                             string special = subElement.Attribute(XName.Get("special")) != null ?
                                 subElement.Attribute(XName.Get("special")).Value : null;
-                            Config.Emulators.Add(new Emulator()
+                            Config.Emulators.Add(new Emulator
                             {
                                 Name = subElement.Attribute(XName.Get("name")).Value,
                                 ProcessName = subElement.Attribute(XName.Get("processName")).Value,
@@ -77,7 +77,7 @@ namespace STROOP.Utilities
                                     ? subElement.Attribute(XName.Get("offsetDll")).Value : null,
                                 Endianness = subElement.Attribute(XName.Get("endianness")).Value == "big" 
                                     ? EndiannessType.Big : EndiannessType.Little,
-                                IOType = special == "dolphin" ? typeof(DolphinProcessIO) : typeof(WindowsProcessRamIO),
+                                IOType = special == "dolphin" ? typeof(DolphinProcessIO) : typeof(WindowsProcessRamIO)
                             });
                         }
                         break;
@@ -99,7 +99,7 @@ namespace STROOP.Utilities
             var assembly = Assembly.GetExecutingAssembly();
 
             // Create schema set
-            var schemaSet = new XmlSchemaSet() { XmlResolver = new ResourceXmlResolver() };
+            var schemaSet = new XmlSchemaSet { XmlResolver = new ResourceXmlResolver() };
             schemaSet.Add("http://tempuri.org/ReusableTypes.xsd", "ReusableTypes.xsd");
             schemaSet.Add("http://tempuri.org/ConfigSchema.xsd", "ConfigSchema.xsd");
             schemaSet.Compile();
@@ -191,7 +191,7 @@ namespace STROOP.Utilities
             var assembly = Assembly.GetExecutingAssembly();
 
             // Create schema set
-            var schemaSet = new XmlSchemaSet() { XmlResolver = new ResourceXmlResolver() };
+            var schemaSet = new XmlSchemaSet { XmlResolver = new ResourceXmlResolver() };
             schemaSet.Add("http://tempuri.org/ReusableTypes.xsd", "ReusableTypes.xsd");
             schemaSet.Add("http://tempuri.org/CameraDataSchema.xsd", schemaFile);
             schemaSet.Compile();
@@ -218,7 +218,7 @@ namespace STROOP.Utilities
             var assembly = Assembly.GetExecutingAssembly();
 
             // Create schema set
-            var schemaSet = new XmlSchemaSet() { XmlResolver = new ResourceXmlResolver() };
+            var schemaSet = new XmlSchemaSet { XmlResolver = new ResourceXmlResolver() };
             schemaSet.Add("http://tempuri.org/ReusableTypes.xsd", "ReusableTypes.xsd");
             schemaSet.Add("http://tempuri.org/ObjectAssociationsSchema.xsd", "ObjectAssociationsSchema.xsd");
             schemaSet.Compile();
@@ -522,7 +522,7 @@ namespace STROOP.Utilities
                                 ParsingUtilities.ParseHex(spawnElement.Attribute(XName.Get("gfxId")).Value) : 0);
                             byte spawnExtra = (byte)(spawnElement.Attribute(XName.Get("extra")) != null ? 
                                 ParsingUtilities.ParseHex(spawnElement.Attribute(XName.Get("extra")).Value) : (byte)(subType.HasValue ? subType : 0));
-                            assoc.AddSpawnHack(new SpawnHack()
+                            assoc.AddSpawnHack(new SpawnHack
                             {
                                 Name = name,
                                 Behavior = behaviorSegmented,
@@ -547,21 +547,21 @@ namespace STROOP.Utilities
                             precursors.Add(precursor);
                         }
 
-                        var newBehavior = new ObjectBehaviorAssociation()
+                        var newBehavior = new ObjectBehaviorAssociation
                         {
-                            Criteria = new BehaviorCriteria()
+                            Criteria = new BehaviorCriteria
                             {
                                 BehaviorAddress = behaviorSegmented,
                                 GfxId = gfxId,
                                 SubType = subType,
                                 Appearance = appearance,
-                                SpawnObj = spawnObj,
+                                SpawnObj = spawnObj
                             },
                             ImagePath = imagePath,
                             MapImagePath = mapImagePath,
                             Name = name,
                             RotatesOnMap = rotates,
-                            Precursors = precursors,
+                            Precursors = precursors
                         };
 
                         if (!assoc.AddAssociation(newBehavior))
@@ -640,7 +640,7 @@ namespace STROOP.Utilities
 
             foreach (var obj in assoc.BehaviorAssociations)
             {
-                if (obj.ImagePath == null || obj.ImagePath == "")
+                if (string.IsNullOrEmpty(obj.ImagePath))
                     continue;
 
                 using (var preLoad = Image.FromFile(imageDir + obj.ImagePath))
@@ -648,7 +648,7 @@ namespace STROOP.Utilities
                     float scale = Math.Max(preLoad.Height / 128f, preLoad.Width / 128f);
                     obj.Image = new Bitmap(preLoad, new Size((int)(preLoad.Width / scale), (int)(preLoad.Height / scale)));
                 }
-                if (obj.MapImagePath == "" || obj.MapImagePath == null)
+                if (string.IsNullOrWhiteSpace(obj.MapImagePath))
                 {
                     obj.MapImage = obj.Image;
                 }
@@ -716,7 +716,7 @@ namespace STROOP.Utilities
             var assembly = Assembly.GetExecutingAssembly();
 
             // Create schema set
-            var schemaSet = new XmlSchemaSet() { XmlResolver = new ResourceXmlResolver() };
+            var schemaSet = new XmlSchemaSet { XmlResolver = new ResourceXmlResolver() };
             schemaSet.Add("http://tempuri.org/ReusableTypes.xsd", "ReusableTypes.xsd");
             schemaSet.Add("http://tempuri.org/InputImageAssociationsSchema.xsd", "InputImageAssociationsSchema.xsd");
             schemaSet.Compile();
@@ -833,7 +833,7 @@ namespace STROOP.Utilities
 
             // Load Images
             // TODO: Exceptions
-            return new InputImageGui()
+            return new InputImageGui
             {
                 InputDisplayType = inputDisplayType,
 
@@ -868,7 +868,7 @@ namespace STROOP.Utilities
             var assembly = Assembly.GetExecutingAssembly();
 
             // Create schema set
-            var schemaSet = new XmlSchemaSet() { XmlResolver = new ResourceXmlResolver() };
+            var schemaSet = new XmlSchemaSet { XmlResolver = new ResourceXmlResolver() };
             schemaSet.Add("http://tempuri.org/ReusableTypes.xsd", "ReusableTypes.xsd");
             schemaSet.Add("http://tempuri.org/FileImageAssociationsSchema.xsd", "FileImageAssociationsSchema.xsd");
             schemaSet.Compile();
@@ -1150,7 +1150,7 @@ namespace STROOP.Utilities
             var assembly = Assembly.GetExecutingAssembly();
 
             // Create schema set
-            var schemaSet = new XmlSchemaSet() { XmlResolver = new ResourceXmlResolver() };
+            var schemaSet = new XmlSchemaSet { XmlResolver = new ResourceXmlResolver() };
             schemaSet.Add("http://tempuri.org/ReusableTypes.xsd", "ReusableTypes.xsd");
             schemaSet.Add("http://tempuri.org/MapAssociationsSchema.xsd", "MapAssociationsSchema.xsd");
             schemaSet.Compile();
@@ -1175,7 +1175,7 @@ namespace STROOP.Utilities
                                     assoc.BackgroundImageFolderPath = subElement.Value;
                                     break;
                                 case "DefaultImage":
-                                    var defaultMap = new MapLayout() { ImagePath = subElement.Value };
+                                    var defaultMap = new MapLayout { ImagePath = subElement.Value };
                                     assoc.DefaultMap = defaultMap;
                                     break;
                                 case "DefaultCoordinates":
@@ -1195,10 +1195,10 @@ namespace STROOP.Utilities
                             string name = element.Attribute(XName.Get("name")).Value;
                             string imagePath = element.Element(XName.Get("Image")).Attribute(XName.Get("path")).Value;
                             Bitmap image = Image.FromFile(assoc.BackgroundImageFolderPath + imagePath) as Bitmap;
-                            BackgroundImage backgroundImage = new BackgroundImage()
+                            BackgroundImage backgroundImage = new BackgroundImage
                             {
                                 Name = name,
-                                Image = image,
+                                Image = image
                             };
                             assoc.AddBackgroundImage(backgroundImage);
                         }
@@ -1233,7 +1233,7 @@ namespace STROOP.Utilities
 
                             var coordinates = new RectangleF(x1, z1, x2 - x1, z2 - z1);
 
-                            MapLayout map = new MapLayout()
+                            MapLayout map = new MapLayout
                             {
                                 Id = id,
                                 Level = level,
@@ -1245,7 +1245,7 @@ namespace STROOP.Utilities
                                 Y = y,
                                 Name = name,
                                 SubName = subName,
-                                Background = backgroundImage,
+                                Background = backgroundImage
                             };
 
                             assoc.AddAssociation(map);
@@ -1263,7 +1263,7 @@ namespace STROOP.Utilities
             var assembly = Assembly.GetExecutingAssembly();
 
             // Create schema set
-            var schemaSet = new XmlSchemaSet() { XmlResolver = new ResourceXmlResolver() };
+            var schemaSet = new XmlSchemaSet { XmlResolver = new ResourceXmlResolver() };
             schemaSet.Add("http://tempuri.org/ReusableTypes.xsd", "ReusableTypes.xsd");
             schemaSet.Add("http://tempuri.org/ScriptsSchema.xsd", "ScriptsSchema.xsd");
             schemaSet.Compile();
@@ -1311,7 +1311,7 @@ namespace STROOP.Utilities
             var assembly = Assembly.GetExecutingAssembly();
 
             // Create schema set
-            var schemaSet = new XmlSchemaSet() { XmlResolver = new ResourceXmlResolver() };
+            var schemaSet = new XmlSchemaSet { XmlResolver = new ResourceXmlResolver() };
             schemaSet.Add("http://tempuri.org/ScriptsSchema.xsd", "ScriptsSchema.xsd");
             schemaSet.Compile();
 
@@ -1362,7 +1362,7 @@ namespace STROOP.Utilities
             var assembly = Assembly.GetExecutingAssembly();
 
             // Create schema set
-            var schemaSet = new XmlSchemaSet() { XmlResolver = new ResourceXmlResolver() };
+            var schemaSet = new XmlSchemaSet { XmlResolver = new ResourceXmlResolver() };
             schemaSet.Add("http://tempuri.org/ActionTableSchema.xsd", "ActionTableSchema.xsd");
             schemaSet.Compile();
 
@@ -1394,7 +1394,7 @@ namespace STROOP.Utilities
                             ParsingUtilities.ParseHex(element.Attribute(XName.Get("afterUncloneValue")).Value) : (uint?) null;
                         uint? handsfreeValue = element.Attribute(XName.Get("handsfreeValue")) != null ?
                             ParsingUtilities.ParseHex(element.Attribute(XName.Get("handsfreeValue")).Value) : (uint?)null;
-                        actionTable?.Add(new ActionTable.ActionReference()
+                        actionTable?.Add(new ActionTable.ActionReference
                         {
                             Action = actionValue,
                             ActionName = actionName,
@@ -1415,7 +1415,7 @@ namespace STROOP.Utilities
             var assembly = Assembly.GetExecutingAssembly();
 
             // Create schema set
-            var schemaSet = new XmlSchemaSet() { XmlResolver = new ResourceXmlResolver() };
+            var schemaSet = new XmlSchemaSet { XmlResolver = new ResourceXmlResolver() };
             schemaSet.Add("http://tempuri.org/AnimationTableSchema.xsd", "AnimationTableSchema.xsd");
             schemaSet.Compile();
 
@@ -1427,7 +1427,7 @@ namespace STROOP.Utilities
             {
                 int animationValue = (int)ParsingUtilities.ParseIntNullable(element.Attribute(XName.Get("value")).Value);
                 string animationName = element.Attribute(XName.Get("name")).Value;
-                animationTable.Add(new AnimationTable.AnimationReference()
+                animationTable.Add(new AnimationTable.AnimationReference
                 {
                     AnimationValue = animationValue,
                     AnimationName = animationName
@@ -1443,7 +1443,7 @@ namespace STROOP.Utilities
             var assembly = Assembly.GetExecutingAssembly();
 
             // Create schema set
-            var schemaSet = new XmlSchemaSet() { XmlResolver = new ResourceXmlResolver() };
+            var schemaSet = new XmlSchemaSet { XmlResolver = new ResourceXmlResolver() };
             schemaSet.Add("http://tempuri.org/TriangleInfoTableSchema.xsd", "TriangleInfoTableSchema.xsd");
             schemaSet.Compile();
 
@@ -1459,12 +1459,12 @@ namespace STROOP.Utilities
                     element.Attribute(XName.Get("slipperiness")).Value);
                 bool exertion = bool.Parse(element.Attribute(XName.Get("exertion")).Value);
 
-                table?.Add(new TriangleInfoTable.TriangleInfoReference()
+                table?.Add(new TriangleInfoTable.TriangleInfoReference
                 {
                     Type = type,
                     Description = description,
                     Slipperiness = slipperiness,
-                    Exertion = exertion,
+                    Exertion = exertion
                 });
             }
 
@@ -1477,7 +1477,7 @@ namespace STROOP.Utilities
             var assembly = Assembly.GetExecutingAssembly();
 
             // Create schema set
-            var schemaSet = new XmlSchemaSet() { XmlResolver = new ResourceXmlResolver() };
+            var schemaSet = new XmlSchemaSet { XmlResolver = new ResourceXmlResolver() };
             schemaSet.Add("http://tempuri.org/CourseDataTableSchema.xsd", "CourseDataTableSchema.xsd");
             schemaSet.Compile();
 
@@ -1492,7 +1492,7 @@ namespace STROOP.Utilities
                 string shortName = element.Attribute(XName.Get("shortName")).Value;
                 byte maxCoinsWithoutGlitches = (byte)ParsingUtilities.ParseIntNullable(element.Attribute(XName.Get("maxCoinsWithoutGlitches")).Value);
                 byte maxCoinsWithGlitches = (byte)ParsingUtilities.ParseIntNullable(element.Attribute(XName.Get("maxCoinsWithGlitches")).Value);
-                courseDataTable.Add(new CourseDataTable.CourseDataReference()
+                courseDataTable.Add(new CourseDataTable.CourseDataReference
                 {
                     Index = index,
                     FullName = fullName,
@@ -1511,7 +1511,7 @@ namespace STROOP.Utilities
             var assembly = Assembly.GetExecutingAssembly();
 
             // Create schema set
-            var schemaSet = new XmlSchemaSet() { XmlResolver = new ResourceXmlResolver() };
+            var schemaSet = new XmlSchemaSet { XmlResolver = new ResourceXmlResolver() };
             schemaSet.Add("http://tempuri.org/PendulumSwingTableSchema.xsd", "PendulumSwingTableSchema.xsd");
             schemaSet.Compile();
 
@@ -1523,7 +1523,7 @@ namespace STROOP.Utilities
             {
                 int index = (int)ParsingUtilities.ParseIntNullable(element.Attribute(XName.Get("index")).Value);
                 int amplitude = (int)ParsingUtilities.ParseIntNullable(element.Attribute(XName.Get("amplitude")).Value);
-                pendulumSwingTable.Add(new PendulumSwingTable.PendulumSwingReference()
+                pendulumSwingTable.Add(new PendulumSwingTable.PendulumSwingReference
                 {
                     Index = index,
                     Amplitude = amplitude
@@ -1568,7 +1568,7 @@ namespace STROOP.Utilities
             var assembly = Assembly.GetExecutingAssembly();
 
             // Create schema set
-            var schemaSet = new XmlSchemaSet() { XmlResolver = new ResourceXmlResolver() };
+            var schemaSet = new XmlSchemaSet { XmlResolver = new ResourceXmlResolver() };
             schemaSet.Add("http://tempuri.org/WaypointTableSchema.xsd", "WaypointTableSchema.xsd");
             schemaSet.Compile();
 
@@ -1583,12 +1583,12 @@ namespace STROOP.Utilities
                 short x = (short)ParsingUtilities.ParseIntNullable(element.Attribute(XName.Get("x")).Value);
                 short y = (short)ParsingUtilities.ParseIntNullable(element.Attribute(XName.Get("y")).Value);
                 short z = (short)ParsingUtilities.ParseIntNullable(element.Attribute(XName.Get("z")).Value);
-                waypoints.Add(new WaypointTable.WaypointReference()
+                waypoints.Add(new WaypointTable.WaypointReference
                 {
                     Index = index,
                     X = x,
                     Y = y,
-                    Z = z,
+                    Z = z
                 });
             }
 
@@ -1600,7 +1600,7 @@ namespace STROOP.Utilities
             var assembly = Assembly.GetExecutingAssembly();
 
             // Create schema set
-            var schemaSet = new XmlSchemaSet() { XmlResolver = new ResourceXmlResolver() };
+            var schemaSet = new XmlSchemaSet { XmlResolver = new ResourceXmlResolver() };
             schemaSet.Add("http://tempuri.org/WaypointTableSchema.xsd", "WaypointTableSchema.xsd");
             schemaSet.Compile();
 
@@ -1615,12 +1615,12 @@ namespace STROOP.Utilities
                 double x = ParsingUtilities.ParseDouble(element.Attribute(XName.Get("x")).Value);
                 double y = ParsingUtilities.ParseDouble(element.Attribute(XName.Get("y")).Value);
                 double z = ParsingUtilities.ParseDouble(element.Attribute(XName.Get("z")).Value);
-                points.Add(new PointTable.PointReference()
+                points.Add(new PointTable.PointReference
                 {
                     Index = index,
                     X = x,
                     Y = y,
-                    Z = z,
+                    Z = z
                 });
             }
 
@@ -1632,7 +1632,7 @@ namespace STROOP.Utilities
             var assembly = Assembly.GetExecutingAssembly();
 
             // Create schema set
-            var schemaSet = new XmlSchemaSet() { XmlResolver = new ResourceXmlResolver() };
+            var schemaSet = new XmlSchemaSet { XmlResolver = new ResourceXmlResolver() };
             schemaSet.Add("http://tempuri.org/WaypointTableSchema.xsd", "WaypointTableSchema.xsd");
             schemaSet.Compile();
 
@@ -1657,7 +1657,7 @@ namespace STROOP.Utilities
             var assembly = Assembly.GetExecutingAssembly();
 
             // Create schema set
-            var schemaSet = new XmlSchemaSet() { XmlResolver = new ResourceXmlResolver() };
+            var schemaSet = new XmlSchemaSet { XmlResolver = new ResourceXmlResolver() };
             schemaSet.Add("http://tempuri.org/MissionTableSchema.xsd", "MissionTableSchema.xsd");
             schemaSet.Compile();
 
@@ -1672,13 +1672,13 @@ namespace STROOP.Utilities
                 int inGameCourseIndex = (int)ParsingUtilities.ParseIntNullable(element.Attribute(XName.Get("inGameCourseIndex")).Value);
                 int inGameMissionIndex = (int)ParsingUtilities.ParseIntNullable(element.Attribute(XName.Get("inGameMissionIndex")).Value);
                 string missionName = element.Attribute(XName.Get("missionName")).Value;
-                missionTable.Add(new MissionTable.MissionReference()
+                missionTable.Add(new MissionTable.MissionReference
                 {
                     CourseIndex = courseIndex,
                     MissionIndex = missionIndex,
                     InGameCourseIndex = inGameCourseIndex,
                     InGameMissionIndex = inGameMissionIndex,
-                    MissionName = missionName,
+                    MissionName = missionName
                 });
             }
 
@@ -1692,7 +1692,7 @@ namespace STROOP.Utilities
             var assembly = Assembly.GetExecutingAssembly();
 
             // Create schema set
-            var schemaSet = new XmlSchemaSet() { XmlResolver = new ResourceXmlResolver() };
+            var schemaSet = new XmlSchemaSet { XmlResolver = new ResourceXmlResolver() };
             schemaSet.Add("http://tempuri.org/ValueListSchema.xsd", "ValueListSchema.xsd");
             schemaSet.Compile();
 
@@ -1718,7 +1718,7 @@ namespace STROOP.Utilities
             var assembly = Assembly.GetExecutingAssembly();
 
             // Create schema set
-            var schemaSet = new XmlSchemaSet() { XmlResolver = new ResourceXmlResolver() };
+            var schemaSet = new XmlSchemaSet { XmlResolver = new ResourceXmlResolver() };
             schemaSet.Add("http://tempuri.org/ValueListSchema.xsd", "ValueListSchema.xsd");
             schemaSet.Compile();
 


### PR DESCRIPTION
I used a linter on the codebase and fixed some formatting issues and tried to remove redundancy. Here, I:

- Removed unneeded empty argument lists before list declarations (for instance, I replaced `new List<String>() { "foo", "bar" }` with `new List<String> { "foo", "barr" }`)
- Removed unnecessary commas in array declarations (`{ "foo", "bar", }` -> `{ "foo", "bar" }`)
- Removed double semicolons (`;;` -> `;`)
- Removed unnecessary lambdas (`() => DoSomething()` -> `DoSomething`)
- Changed the project file to use the build-in `Copy` tag instead of the `xcopy` batch command.