### PR TITLE
Fix some BizHawk issues

### DIFF
--- a/STROOP/Config/Config.xml
+++ b/STROOP/Config/Config.xml
@@ -10,7 +10,7 @@
     <Emulator name="Mupen 5.0 RR" processName="mupen64-rrv8-avisplit" ramStart="0x008ECBB0" endianness="little"/>
 
     <Emulator name="Nemu64 0.8" processName="Nemu64" ramStart="0x10020000" endianness="little"/>
-    <Emulator name="BizHawk" processName="EmuHawk" offsetDll="mupen64plus.dll" ramStart="0x6A1C0" endianness="little"/>
+    <Emulator name="BizHawk" processName="EmuHawk" offsetDll="mupen64plus.dll" ramStart="0x6A1E0" endianness="little"/>
     <Emulator name="Project64 Debugger 2.4.0.9999" processName="Project64d" ramStart="0x20000000" endianness="little"/>
     <Emulator name="Project64" processName="Project64" ramStart="0x4BAF0000" endianness="little"/>
     <Emulator name="Dolphin" processName="Dolphin" ramStart="0xe6a180" endianness="big" special="dolphin"/>

--- a/STROOP/Utilities/Stream/WindowsProcessIO.cs
+++ b/STROOP/Utilities/Stream/WindowsProcessIO.cs
@@ -76,7 +76,7 @@ namespace STROOP.Utilities
             if (_emulator != null && _emulator.Dll != null)
             {
                 ProcessModule dll = _process.Modules.Cast<ProcessModule>()
-                    ?.FirstOrDefault(d => d.ModuleName == _emulator.Dll);
+                    ?.FirstOrDefault(d => d.ModuleName.Equals(_emulator.Dll, StringComparison.OrdinalIgnoreCase));
 
                 if (dll == null)
                     throw new ArgumentNullException("Could not find ");


### PR DESCRIPTION
OS: Windows 10 Pro (x64) Build 18363
BizHawk Version: BizHawk 2.4.0

This pull request fixes issues, which prevent STROOP from working with the latest version of BizHawk.
Those include:
-  Making the mupen64-DLL search case insensitive ("mupen64plus.dll" vs "mupen64plus.DLL")
-  Changing the RAM offset (might be machine dependent) 