### PR TITLE
Add support for mupen64plus emulator

### DIFF
--- a/STROOP/Config/Config.xml
+++ b/STROOP/Config/Config.xml
@@ -14,7 +14,7 @@
     <Emulator name="Project64 Debugger 2.4.0.9999" processName="Project64d" ramStart="0x20000000" endianness="little"/>
     <Emulator name="Project64" processName="Project64" ramStart="0x4BAF0000" endianness="little"/>
     <Emulator name="Dolphin" processName="Dolphin" ramStart="0xe6a180" endianness="big" special="dolphin"/>
-    <Emulator name="Mupen64Plus" processName="mupen64plus" ramStart="0x008FF142‬" endianness="little"/>
+    <Emulator name="Mupen64Plus" processName="mupen64plus" ramStart="0x008FF142" endianness="little"/>
   </Emulators>
 
   <!-- US, JP, or SH -->

--- a/STROOP/Config/Config.xml
+++ b/STROOP/Config/Config.xml
@@ -14,6 +14,7 @@
     <Emulator name="Project64 Debugger 2.4.0.9999" processName="Project64d" ramStart="0x20000000" endianness="little"/>
     <Emulator name="Project64" processName="Project64" ramStart="0x4BAF0000" endianness="little"/>
     <Emulator name="Dolphin" processName="Dolphin" ramStart="0xe6a180" endianness="big" special="dolphin"/>
+    <Emulator name="Mupen64Plus" processName="mupen64plus" ramStart="0x008FF142‬" endianness="little"/>
   </Emulators>
 
   <!-- US, JP, or SH -->


### PR DESCRIPTION
With the help of @onlymx13, we found that the actual address of coin count in N64 for US version is `0x8033B218`.
I've found that the coin count offset for `mupen64plus` (US version of the game) is `0xC3A35A`. So, if I didn't made any mistake when finding the coin offset, we can do the difference between the 2 values :

`abs(0x8033B218 - 0x80C3A35A) = 0x008FF142‬`

and found that `ramStart` for `mupen64plus` should be `0x008FF142‬`.

I've not tested it because I don't have a Windows machine and as for now, I cannot connect to a running emulator on GNU/Linux.

If someone with a Windows machine could test that STROOP can connect to `mupen64plus`, that would be great. Thank you very much.