### PR TITLE
Revive unit test project

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
 	<PropertyGroup>
 		<DefineConstants>$(DefineConstants);TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
+		<LangVersion>7.1</LangVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
 		<DebugSymbols>true</DebugSymbols>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,16 @@
+<Project>
+	<PropertyGroup>
+		<DefineConstants>$(DefineConstants);TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+		<DebugSymbols>true</DebugSymbols>
+		<DebugType>full</DebugType>
+		<DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+		<Optimize>false</Optimize>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+		<DebugType>pdbonly</DebugType>
+		<Optimize>true</Optimize>
+	</PropertyGroup>
+</Project>

--- a/STROOP/STROOP.csproj
+++ b/STROOP/STROOP.csproj
@@ -34,8 +34,6 @@
 		</NuGetPackageImportStamp>
 		<ApplicationIcon>icon.ico</ApplicationIcon>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
-		<DefineConstants>$(DefineConstants);TRACE</DefineConstants>
-		<ErrorReport>prompt</ErrorReport>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
 		<MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MSB3277</MSBuildWarningsAsMessages> <!-- Accord's maintainer messed up the metadata, and since the project is archived, it will never be fixed -->
@@ -43,16 +41,6 @@
 		<PlatformTarget>$(Platform)</PlatformTarget>
 		<SignAssembly>false</SignAssembly>
 		<SignManifests>false</SignManifests>
-	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-		<DebugSymbols>true</DebugSymbols>
-		<DebugType>full</DebugType>
-		<DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
-		<Optimize>false</Optimize>
-	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-		<DebugType>pdbonly</DebugType>
-		<Optimize>true</Optimize>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)' == 'Windows Build' ">
 		<DebugType>none</DebugType>
@@ -83,24 +71,10 @@
 		<PackageReference Include="OpenTK" Version="3.1.0" />
 		<PackageReference Include="OpenTK.GLControl" Version="3.1.0" />
 		<Reference Include="PresentationCore" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
-		<Reference Include="System.Xaml" />
-		<Reference Include="System.Xml.Linq" />
-		<Reference Include="System.Data.DataSetExtensions" />
-		<Reference Include="Microsoft.CSharp" />
-		<Reference Include="System.Data" />
-		<Reference Include="System.Deployment" />
-		<Reference Include="System.Drawing" />
-		<Reference Include="System.Net.Http" />
 		<PackageReference Include="System.Resources.Extensions" Version="4.6.0" /> <!-- "4.0.0" required by Resources for some reason-->
 		<Reference Include="System.Windows.Forms" />
-		<Reference Include="System.Xml" />
-		<Reference Include="UIAutomationProvider" />
 		<Reference Include="WindowsBase" />
-		<Reference Include="WindowsFormsIntegration" />
 	</ItemGroup>
 	<ItemGroup>
 		<Content Include="Config\**\*.xml" />

--- a/STROOPUnitTests/STROOPUnitTests.csproj
+++ b/STROOPUnitTests/STROOPUnitTests.csproj
@@ -1,4 +1,4 @@
-﻿﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
 		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -17,21 +17,9 @@
 		<TestProjectType>UnitTest</TestProjectType>
 		<NuGetPackageImportStamp>
 		</NuGetPackageImportStamp>
-		<DefineConstants>$(DefineConstants);TRACE</DefineConstants>
 		<EnableMSTestRunner>true</EnableMSTestRunner>
-		<ErrorReport>prompt</ErrorReport>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<WarningLevel>4</WarningLevel>
-	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-		<DebugSymbols>true</DebugSymbols>
-		<DebugType>full</DebugType>
-		<DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
-		<Optimize>false</Optimize>
-	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-		<DebugType>pdbonly</DebugType>
-		<Optimize>true</Optimize>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="MSTest" Version="3.3.1" PrivateAssets="all" />

--- a/STROOPUnitTests/STROOPUnitTests.csproj
+++ b/STROOPUnitTests/STROOPUnitTests.csproj
@@ -1,79 +1,40 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{14542232-E0B6-4FDD-8B35-8F3EAE889C51}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>STROOPUnitTests</RootNamespace>
-    <AssemblyName>STROOPUnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
-    <IsCodedUITest>False</IsCodedUITest>
-    <TestProjectType>UnitTest</TestProjectType>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.4.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.4.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Mocks\MockEmuIO.cs" />
-    <Compile Include="ProcessStreamTests.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="app.config" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\STROOP\STROOP.csproj">
-      <Project>{d309a4ed-54af-4bc7-83ca-bcd38543aeb3}</Project>
-      <Name>STROOP</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets'))" />
-  </Target>
-  <Import Project="..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets')" />
+﻿﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<ProjectGuid>{14542232-E0B6-4FDD-8B35-8F3EAE889C51}</ProjectGuid>
+		<OutputType>Exe</OutputType>
+		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<RootNamespace>STROOPUnitTests</RootNamespace>
+		<AssemblyName>STROOPUnitTests</AssemblyName>
+		<TargetFramework>net462</TargetFramework>
+		<FileAlignment>512</FileAlignment>
+		<ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+		<VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+		<VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+		<ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+		<IsCodedUITest>False</IsCodedUITest>
+		<TestProjectType>UnitTest</TestProjectType>
+		<NuGetPackageImportStamp>
+		</NuGetPackageImportStamp>
+		<DefineConstants>$(DefineConstants);TRACE</DefineConstants>
+		<EnableMSTestRunner>true</EnableMSTestRunner>
+		<ErrorReport>prompt</ErrorReport>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<WarningLevel>4</WarningLevel>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+		<DebugSymbols>true</DebugSymbols>
+		<DebugType>full</DebugType>
+		<DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+		<Optimize>false</Optimize>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+		<DebugType>pdbonly</DebugType>
+		<Optimize>true</Optimize>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="MSTest" Version="3.3.1" PrivateAssets="all" />
+		<ProjectReference Include="$(ProjectDir)../STROOP/STROOP.csproj" />
+	</ItemGroup>
 </Project>

--- a/STROOPUnitTests/STROOPUnitTests.csproj
+++ b/STROOPUnitTests/STROOPUnitTests.csproj
@@ -7,7 +7,7 @@
 		<AppDesignerFolder>Properties</AppDesignerFolder>
 		<RootNamespace>STROOPUnitTests</RootNamespace>
 		<AssemblyName>STROOPUnitTests</AssemblyName>
-		<TargetFramework>net462</TargetFramework>
+		<TargetFramework>net461</TargetFramework>
 		<FileAlignment>512</FileAlignment>
 		<ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
 		<VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
@@ -24,5 +24,14 @@
 	<ItemGroup>
 		<PackageReference Include="MSTest" Version="3.3.1" PrivateAssets="all" />
 		<ProjectReference Include="$(ProjectDir)../STROOP/STROOP.csproj" />
+	</ItemGroup>
+
+	<!-- newer versions of Microsoft.NET.Test.Sdk silently fail for net461, but with this incantation it works fine, see https://github.com/microsoft/vstest/issues/4187#issuecomment-1346833455 -->
+	<PropertyGroup>
+		<IsTestProject>true</IsTestProject>
+		<TestProject>true</TestProject>
+	</PropertyGroup>
+	<ItemGroup>
+		<ProjectCapability Include="TestContainer" />
 	</ItemGroup>
 </Project>

--- a/STROOPUnitTests/packages.config
+++ b/STROOPUnitTests/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="MSTest.TestAdapter" version="1.4.0" targetFramework="net461" />
-  <package id="MSTest.TestFramework" version="1.4.0" targetFramework="net461" />
-  <package id="System.Runtime" version="4.3.1" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
-</packages>


### PR DESCRIPTION
Switched to new format as I did for the main project in #96, but all at once this time because it's relatively simple. ~~I had to bump the TFM to `net462` for one of the NuGet packages, but I don't expect that will ever be an issue.~~ (And I learned .NET Framework tests run on Linux.)
Explicitly pinned C# version at 7.1, though it could have been 7.0 but for one file. (When .NET Framework 4.6.1 released the latest would have been 6, but obviously the project adopted 7.0 soon after because tuples are used heavily.) I suggest you resolve all the existing warnings—and maybe add more Analyzers and fix their warnings too—before switching to 12 and adopting new features. Maybe you could go for 7.3 immediately, but 8 would be huge in terms of how much of the codebase you'll want to touch.